### PR TITLE
웹폰트 지원을 위한 CSS 파일 추가

### DIFF
--- a/dist/web/static/index.css
+++ b/dist/web/static/index.css
@@ -1,0 +1,89 @@
+/*
+Copyright (c) 2021 Kil Hyung-jin, with Reserved Font Name Pretendard.
+https://github.com/orioncactus/pretendard
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+*/
+
+@font-face {
+  font-family: 'Pretendard';
+  font-weight: 900;
+  font-display: swap;
+  src: local('Pretendard Black'),
+  url('../woff2/Pretendard-Black.woff2') format('woff2'),
+  url('../woff/Pretendard-Black.woff') format('woff'),
+}
+
+@font-face {
+  font-family: 'Pretendard';
+  font-weight: 800;
+  font-display: swap;
+  src: local('Pretendard ExtraBold'),
+  url('../woff2/Pretendard-ExtraBold.woff2') format('woff2'),
+  url('../woff/Pretendard-ExtraBold.woff') format('woff'),
+}
+
+@font-face {
+  font-family: 'Pretendard';
+  font-weight: 700;
+  font-display: swap;
+  src: local('Pretendard Bold'),
+  url('../woff2/Pretendard-Bold.woff2') format('woff2'),
+  url('../woff/Pretendard-Bold.woff') format('woff'),
+}
+
+@font-face {
+  font-family: 'Pretendard';
+  font-weight: 600;
+  font-display: swap;
+  src: local('Pretendard SemiBold'),
+  url('../woff2/Pretendard-SemiBold.woff2') format('woff2'),
+  url('../woff/Pretendard-SemiBold.woff') format('woff'),
+}
+
+@font-face {
+  font-family: 'Pretendard';
+  font-weight: 500;
+  font-display: swap;
+  src: local('Pretendard Medium'),
+  url('../woff2/Pretendard-Medium.woff2') format('woff2'),
+  url('../woff/Pretendard-Medium.woff') format('woff'),
+}
+
+@font-face {
+  font-family: 'Pretendard';
+  font-weight: 400;
+  font-display: swap;
+  src: local('Pretendard Regular'),
+  url('../woff2/Pretendard-Regular.woff2') format('woff2'),
+  url('../woff/Pretendard-Regular.woff') format('woff'),
+}
+
+@font-face {
+  font-family: 'Pretendard';
+  font-weight: 300;
+  font-display: swap;
+  src: local('Pretendard Light'),
+  url('../woff2/Pretendard-Light.woff2') format('woff2'),
+  url('../woff/Pretendard-Light.woff') format('woff'),
+}
+
+@font-face {
+  font-family: 'Pretendard';
+  font-weight: 200;
+  font-display: swap;
+  src: local('Pretendard ExtraLight'),
+  url('../woff2/Pretendard-ExtraLight.woff2') format('woff2'),
+  url('../woff/Pretendard-ExtraLight.woff') format('woff'),
+}
+
+@font-face {
+  font-family: 'Pretendard';
+  font-weight: 100;
+  font-display: swap;
+  src: local('Pretendard Thin'),
+  url('../woff2/Pretendard-Thin.woff2') format('woff2'),
+  url('../woff/Pretendard-Thin.woff') format('woff'),
+}


### PR DESCRIPTION
[JSDelivr](https://www.jsdelivr.com/) 등의 CDN을 통해 웹폰트를 바로 끌어와 사용할 수 있도록 CSS 파일을 추가하였습니다.  
본 PR이 머지된다면 아래의 주소로 웹폰트를 불러올 수 있습니다.

```
https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/index.css
```