### PR TITLE
Fix typo on example docs

### DIFF
--- a/examples/react_native_pretendard/README.md
+++ b/examples/react_native_pretendard/README.md
@@ -1,5 +1,5 @@
 # React Native
-먼저 본 예제를 작성하는 데 (이 글)[https://zeallat94.medium.com/reactnative에서-커스텀-폰트-사용하기-b4b221d6a731]을 참조했음을 밝힙니다.
+먼저 본 예제를 작성하는 데 [이 글](https://zeallat94.medium.com/reactnative에서-커스텀-폰트-사용하기-b4b221d6a731)을 참조했음을 밝힙니다.
 
 ## 디렉터리 구성
 핵심적인 파일/폴더만 남기면 다음과 같습니다.


### PR DESCRIPTION
#12 에서 추가된 예제 문서의 하이퍼링크 문법 오류를 수정했습니다!