### PR TITLE
[#37] 릴리즈 시 JSDelivr 캐시 초기화 (#1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,3 +71,12 @@ jobs:
       with:
         files: |
           dist/Pretendard-${{ env.RELEASE_NAME }}.zip
+
+  cache-invalidation:
+    needs: upload
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Purge JSDelivr cache
+      run: |
+        https://purge.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static


### PR DESCRIPTION
## 개요
GitHub Workflow에 `curl` 로 JSDelivr에 Purge를 위한 `GET` 요청을 보냅니다.
자세한 내용은 #37을 참조해주세요.