### PR TITLE
Pretendard를 사용하는 곳에 rallit 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,12 @@ Pretendard에 기여해주셔서 진심으로 감사드립니다.
    <a href="https://solved.ac/#gh-dark-mode-only">
       <img src="https://user-images.githubusercontent.com/7247848/148689350-ef59e5f6-5e27-4c58-9264-d2c04200ff17.png" align="center" height="50" alt="solved.ac" hspace="16">
    </a>
+   <a href="https://rallit.com/#gh-light-mode-only">
+      <img src="https://user-images.githubusercontent.com/76927618/151356487-9aa7d1f6-9677-47e6-9723-055e0e40aed4.png" align="center" height="50" alt="rallit" hspace="16">
+   </a>
+   <a href="https://rallit.com/#gh-dark-mode-only">
+      <img src="https://user-images.githubusercontent.com/76927618/151355760-998bda56-ff32-47ee-991e-9709db173932.png" align="center" height="50" alt="rallit" hspace="16">
+   </a>
 </p>
 
 ## 의견 나누기


### PR DESCRIPTION
랠릿 (rallit)의 [B2C](https://www.rallit.com/), [B2B](https://business.rallit.com/login) 서비스에서 pretendard 폰트를 사용하고 있습니다.
좋은 폰트 만들어주셔서 감사합니다 :)