### PR TITLE
일본어 번역 개선

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[**한국어**](/README.md) | [English](/docs/readme/en/README.md) | [日本語](/docs/readme/jp/README.md)
+[**한국어**](/README.md) | [English](/docs/readme/en/README.md) | [日本語](/docs/readme/ja/README.md)
 
 # Pretendard
 

--- a/docs/readme/en/README.md
+++ b/docs/readme/en/README.md
@@ -1,4 +1,4 @@
-[한국어](/README.md) | [**English**](/docs/readme/en/README.md) | [日本語](/docs/readme/jp/README.md)
+[한국어](/README.md) | [**English**](/docs/readme/en/README.md) | [日本語](/docs/readme/ja/README.md)
 
 # Pretendard
 

--- a/docs/readme/ja/README.md
+++ b/docs/readme/ja/README.md
@@ -1,15 +1,15 @@
-[한국어](/README.md) | [English](/docs/readme/en/README.md) | [**日本語**](/docs/readme/jp/README.md)
+[한국어](/README.md) | [English](/docs/readme/en/README.md) | [**日本語**](/docs/readme/ja/README.md)
 
 # Pretendard
 
 ![Thumbnail](/thumbnail.svg#gh-light-mode-only)
 ![Thumbnail](/thumbnail-white.svg#gh-dark-mode-only)
 
-Pretendardは、クロスプラットフォームで製品を提供するとき、そして多言語タイポグラフィでも自然な現代的なフォントです。[Inter](https://github.com/rsms/inter)と[源ノ角ゴシック](https://fonts.adobe.com/fonts/source-han-sans-korean)、そして[M PLUS 1p](https://github.com/coz-m/MPLUS_FONTS)に基づいて整えられたPretendardは、読み込み環境で可読性と視覚補正のために追加の作業をする必要はありません。
+Pretendardは、クロスプラットフォームで製品を提供するとき、そして多言語タイポグラフィでも自然な現代的なフォントです。[Inter](https://github.com/rsms/inter)と[源ノ角ゴシック](https://fonts.adobe.com/fonts/source-han-sans-japanese)、そして[M PLUS 1p](https://github.com/coz-m/MPLUS_FONTS)に基づいて整えられたPretendardは、読み込み環境で可読性と視覚補正のために追加の作業をする必要はありません。
 
-Pretendardは9種類の太さで提供され、可変フォントもサポートしています。
+Pretendardは9種類の太さで提供され、可変フォントにも対応しています。
 
-## 背景と物語
+## 背景と概要
 
 Pretendardの背景や特徴、OpenType機能などを説明する詳細な話は[こちら(韓国語)](https://cactus.tistory.com/306)で確認できます。
 
@@ -17,18 +17,18 @@ Pretendardの背景や特徴、OpenType機能などを説明する詳細な話�
 
 ### [最新バージョンをダウンロード](https://github.com/orioncactus/pretendard/releases/latest)
 
-## ウェブフォント
+## Webフォント
 
-CDNを利用してPretendardを使用することができ、トグルを確認して基本的に推奨するjsDelivr以外にもcdnjsとUNPKGの中でお好みのCDNを使用することができます。
+CDNを利用してPretendardを使用することができ、トグルをチェックして基本的に推奨するjsDelivr以外にもcdnjsとUNPKGの中でお好みのCDNを使用することができます。
 
-日本語と韓国の漢字環境、またはラテン環境専用のPretendard Webフォントを使用するには、以下をご覧ください。
+日本語およびKS漢字環境、またはラテン環境専用のPretendardのWebフォントを使用するには、以下をご覧ください。
 
--   [Pretendard JP](/docs/webfonts/jp/PretendardJP.md)
+-   [Pretendard JP](/docs/webfonts/ja/PretendardJP.md)
 -   [Pretendard Std(英語)](/docs/webfonts/en/PretendardStd.md)
 
 ---
 
-すべての機能を含むPretendardをWebフォントとして使用するには、以下のコードを使用してください。使用するfont-familyの名前は`Pretendard`です。
+すべての機能を含むPretendardをWebフォントとして使用するには、下記のコードを使用してください。使用するfont-family名は`Pretendard`です。
 
 #### HTML
 
@@ -38,7 +38,7 @@ CDNを利用してPretendardを使用することができ、トグルを確認�
 
 <details/>
 
-<summary> cdnjsとUNPKG</summary>
+<summary>cdnjsおよびUNPKG</summary>
 
 ###### cdnjs
 
@@ -62,7 +62,7 @@ CDNを利用してPretendardを使用することができ、トグルを確認�
 
 <details/>
 
-<summary> cdnjsとUNPKG</summary>
+<summary>cdnjsおよびUNPKG</summary>
 
 ###### cdnjs
 
@@ -82,7 +82,7 @@ CDNを利用してPretendardを使用することができ、トグルを確認�
 
 ### ダイナミックサブセット
 
-Pretendardは、Webフォントの容量の問題を解決するための方法として、Google Fontsが提供するNoto Sans JPと同じ方法で動的サブセットを提供します。ページに含まれている文字のみを選択的にダウンロードしてより早くPretendardを表示するには、以下のコードを使用してください。使用するfont-familyの名前は`Pretendard`です。
+Pretendardは、Webフォントの容量の問題を解決するための方法として、Google Fontsで提供されるNoto Sans JPと同じ方法で動的サブセットを提供します。ページに含まれている文字のみを選択的にダウンロードしてより早くPretendardを表示するには、下記のコードを使用してください。使用するfont-family名は`Pretendard`です。
 
 #### HTML
 
@@ -92,7 +92,7 @@ Pretendardは、Webフォントの容量の問題を解決するための方法�
 
 <details/>
 
-<summary> cdnjsとUNPKG</summary>
+<summary>cdnjsおよびUNPKG</summary>
 
 ###### cdnjs
 
@@ -116,7 +116,7 @@ Pretendardは、Webフォントの容量の問題を解決するための方法�
 
 <details/>
 
-<summary> cdnjsとUNPKG</summary>
+<summary>cdnjsおよびUNPKG</summary>
 
 ###### cdnjs
 
@@ -136,7 +136,7 @@ Pretendardは、Webフォントの容量の問題を解決するための方法�
 
 ### 可変フォント
 
-可変weightプロパティを使用するには、以下のコードを使用してください。使用するfont-familyの名前は`'Pretendard Variable'`です。
+可変weightプロパティを使用するには、下記のコードを使用してください。使用するfont-family名は`'Pretendard Variable'`です。
 
 #### HTML
 
@@ -146,7 +146,7 @@ Pretendardは、Webフォントの容量の問題を解決するための方法�
 
 <details/>
 
-<summary> cdnjsとUNPKG</summary>
+<summary>cdnjsおよびUNPKG</summary>
 
 ###### cdnjs
 
@@ -170,7 +170,7 @@ Pretendardは、Webフォントの容量の問題を解決するための方法�
 
 <details/>
 
-<summary> cdnjsとUNPKG</summary>
+<summary>cdnjsおよびUNPKG</summary>
 
 ###### cdnjs
 
@@ -190,13 +190,13 @@ Pretendardは、Webフォントの容量の問題を解決するための方法�
 
 ### font-family
 
-システムにできるだけ合わせたいなら、下記のようなfont-family構成をお勧めします。
+システムにできるだけ合わせたいなら、下記のようなfont-family構成をおすすめします。
 
 ```css
 font-family: -apple-system, BlinkMacSystemFont, 'Apple SD Gothic Neo', Pretendard, Roboto, 'Noto Sans KR', 'Segoe UI', 'Malgun Gothic', 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', sans-serif;
 ```
 
-どこでも同じ環境を持ちたければ下記のようなfont-family構成をお勧めします。
+どこでも同じ環境を持ちたければ下記のようなfont-family構成をおすすめします。
 
 ```css
 font-family: Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, 'Helvetica Neue', 'Segoe UI', 'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic', 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', sans-serif;
@@ -220,23 +220,23 @@ yarn add pretendard
 
 ## ライセンス
 
-Pretendardは[SILオープンフォントライセンス](https://scripts.sil.org/OFL)として配布されています。フォント単独販売を除くすべての商業行為、修正、再配布が可能です。
+Pretendardは[SIL Open Font License](https://scripts.sil.org/OFL)として配布されています。フォントの単独販売を除くすべての商業行為、修正、再配布が可能です。
 
-## 貢献者
+## コントリビューター
 
-Pretendardに貢献していただきありがとうございます。
+Pretendardにコントリビュートしていただきありがとうございます。
 
-[@hiddenest](https://github.com/hiddenest)：WebフォントサービングとCDNアップデートの自動化、サブセット作業、そしてダイナミックサブセットを作成しました。
+[@hiddenest](https://github.com/hiddenest): WebフォントサービングとCDNアップデートの自動化、サブセット作業、そしてダイナミックサブセットを作成しました。
 
-[@ leejh10003](https://github.com/leejh10003)：Pretendardを使用した[例](/examples)を作成しました。
+[@ leejh10003](https://github.com/leejh10003): Pretendardが使用された[例](/examples)を作成しました。
 
-[@black7375](https://github.com/black7375)：サブセットとダイナミックサブセットビルドオートメーション、リリースファイル生成オートメーションを作成しました。
+[@black7375](https://github.com/black7375): サブセットとダイナミックサブセットビルドオートメーション、リリースファイル生成オートメーションを作成しました。
 
-[@victorrica](https://github.com/victorrica)：npmとYarnパッケージの配布に取り組んできました。
+[@victorrica](https://github.com/victorrica): npmとYarnパッケージの配布に取り組んできました。
 
-[@ kms0219kms](https://github.com/kms0219kms)：WebフォントのCDN配布多重化に取り組んできました。
+[@ kms0219kms](https://github.com/kms0219kms): WebフォントのCDN配布多重化に取り組んできました。
 
-[@Gamsake](https://github.com/Gamsake)：ビルドの自動化を改善しました。
+[@Gamsake](https://github.com/Gamsake): ビルドの自動化を改善しました。
 
 
 ## Issues

--- a/docs/readme/ja/README.md
+++ b/docs/readme/ja/README.md
@@ -228,15 +228,15 @@ Pretendardにコントリビュートしていただきありがとうござい�
 
 [@hiddenest](https://github.com/hiddenest): WebフォントサービングとCDNアップデートの自動化、サブセット作業、そしてダイナミックサブセットを作成しました。
 
-[@ leejh10003](https://github.com/leejh10003): Pretendardが使用された[例](/examples)を作成しました。
+[@leejh10003](https://github.com/leejh10003): Pretendardが使用された[例](/examples)を作成しました。
 
-[@black7375](https://github.com/black7375): サブセットとダイナミックサブセットビルドオートメーション、リリースファイル生成オートメーションを作成しました。
+[@black7375](https://github.com/black7375): サブセットとダイナミックサブセットビルド自動化、リリースファイル作成を自動化しました。
 
-[@victorrica](https://github.com/victorrica): npmとYarnパッケージの配布に取り組んできました。
+[@victorrica](https://github.com/victorrica): npmとYarnパッケージの配布を作業しました。
 
-[@ kms0219kms](https://github.com/kms0219kms): WebフォントのCDN配布多重化に取り組んできました。
+[@kms0219kms](https://github.com/kms0219kms): WebフォントのCDN配布多重化を作業しました。
 
-[@Gamsake](https://github.com/Gamsake): ビルドの自動化を改善しました。
+[@Gamsake](https://github.com/Gamsake): ビルド自動化を改善しました。
 
 
 ## Issues

--- a/docs/webfonts/ja/PretendardJP.md
+++ b/docs/webfonts/ja/PretendardJP.md
@@ -1,8 +1,8 @@
 ## Pretendard JP
 
-日本語環境に適しており、すべての機能をサポートするPretendardをWebフォントとして使用するには、以下のコードを使用してください。使用するfont-familyの名前は `'Pretendard JP'`です。
+日本語環境に適しており、すべての機能に対応するPretendardをWebフォントとして使用するには、下記のコードを使用してください。使用するfont-family名は`'Pretendard JP'`です。
 
-韓国に合った外観を使用するには、stylesheetに以下のコードを追加してください。`font-feature-settings: 'ss05';`
+韓国語環境に合った外観を使用するには、stylesheetに次のコードを追加してください。`font-feature-settings: 'ss05';`
 
 #### HTML
 
@@ -12,7 +12,7 @@
 
 <details>
 
-<summary>cdnjsとUNPKG</summary>
+<summary>cdnjsおよびUNPKG</summary>
 
 ###### cdnjs
 
@@ -36,7 +36,7 @@
 
 <details>
 
-<summary>cdnjsとUNPKG</summary>
+<summary>cdnjsおよびUNPKG</summary>
 
 ###### cdnjs
 
@@ -56,7 +56,7 @@
 
 ### ダイナミックサブセット
 
-日本語環境でページに含まれている文字のみを選択的にダウンロードしてより早くPretendardを表示するには、以下のコードを使用してください。使用するfont-familyの名前は`'Pretendard JP'`です。
+日本語環境でページに含まれている文字のみを選択的にダウンロードしてより早くPretendardを表示するには、下記のコードを使用してください。使用するfont-family名は`'Pretendard JP'`です。
 #### HTML
 
 ```html
@@ -65,7 +65,7 @@
 
 <details>
 
-<summary>cdnjsとUNPKG</summary>
+<summary>cdnjsおよびUNPKG</summary>
 
 ###### cdnjs
 
@@ -89,7 +89,7 @@
 
 <details>
 
-<summary>cdnjsとUNPKG</summary>
+<summary>cdnjsおよびUNPKG</summary>
 
 ###### cdnjs
 
@@ -109,7 +109,7 @@
 
 ### 可変フォント
 
-可変weightプロパティを使用するには、以下のコードを使用してください。使用するfont-familyの名前は `'Pretendard JP Variable'` です。
+可変weightプロパティを使用するには、下記のコードを使用してください。使用するfont-family名は `'Pretendard JP Variable'` です。
 
 #### HTML
 
@@ -119,7 +119,7 @@
 
 <details>
 
-<summary>cdnjsとUNPKG</summary>
+<summary>cdnjsおよびUNPKG</summary>
 
 ###### cdnjs
 
@@ -143,7 +143,7 @@
 
 <details>
 
-<summary>cdnjsとUNPKG</summary>
+<summary>cdnjsおよびUNPKG</summary>
 
 ###### cdnjs
 

--- a/docs/webfonts/ko/PretendardJP.md
+++ b/docs/webfonts/ko/PretendardJP.md
@@ -2,7 +2,7 @@
 
 일본어 환경에 적합하며, 모든 기능을 지원하는 Pretendard를 웹폰트로 사용하려면 아래 코드를 사용하세요. 사용하는 font-family 이름은 `'Pretendard JP'` 입니다.
 
-한국에 맞는 모양을 사용하려면 스타일에 아래와 같은 코드를 추가하세요: `font-feature-settings: 'ss05';`
+한국에 맞는 모양을 사용하려면 스타일에 다음과 같은 코드를 추가하세요: `font-feature-settings: 'ss05';`
 
 #### HTML
 


### PR DESCRIPTION
안녕하세요! 일본어 번역을 개선해봤습니다.

- ISO 639-1에 따른 일본어 언어 코드는 `ja`가 맞으므로 이로 변경하였습니다.
- "お勧め"는 "おすすめ"로 쓰는 경우가 압도적으로 많습니다.
- "를 서포트하다(をサポートする)"보다 "에 대응하다(に対応する)"는 표현이 더 자연스러우며 많이 사용됩니다.
- `docs/webfonts/ko/PretendardJP.md`에 "아래와 같은 코드"라고 되어 있는데 아래가 아닌 것 같아 수정했습니다.