### PR TITLE
v1.3.2 Safari에서 다이나믹 서브셋 이슈 개선

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ CDN을 이용해 Pretendard를 사용할 수 있으며, 토글을 확인해 기�
 ###### cdnjs
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/static/pretendard.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/static/pretendard.css" />
 ```
 
 ###### UNPKG
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.1/dist/web/static/pretendard.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.2/dist/web/static/pretendard.css" />
 ```
 
 </details>
@@ -67,13 +67,13 @@ CDN을 이용해 Pretendard를 사용할 수 있으며, 토글을 확인해 기�
 ###### cdnjs
 
 ```css
-@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/static/pretendard.css');
+@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/static/pretendard.css');
 ```
 
 ###### UNPKG
 
 ```css
-@import url('https://unpkg.com/pretendard@1.3.1/dist/web/static/pretendard.css');
+@import url('https://unpkg.com/pretendard@1.3.2/dist/web/static/pretendard.css');
 ```
 
 </details>
@@ -97,13 +97,13 @@ Pretendard에서는 웹폰트 용량 문제를 해결하기 위한 방법으로 
 ###### cdnjs
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/static/pretendard-dynamic-subset.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/static/pretendard-dynamic-subset.css" />
 ```
 
 ###### UNPKG
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.1/dist/web/static/pretendard-dynamic-subset.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.2/dist/web/static/pretendard-dynamic-subset.css" />
 ```
 
 </details>
@@ -121,13 +121,13 @@ Pretendard에서는 웹폰트 용량 문제를 해결하기 위한 방법으로 
 ###### cdnjs
 
 ```css
-@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/static/pretendard-dynamic-subset.css');
+@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/static/pretendard-dynamic-subset.css');
 ```
 
 ###### UNPKG
 
 ```css
-@import url('https://unpkg.com/pretendard@1.3.1/dist/web/static/pretendard-dynamic-subset.css');
+@import url('https://unpkg.com/pretendard@1.3.2/dist/web/static/pretendard-dynamic-subset.css');
 ```
 
 </details>
@@ -151,13 +151,13 @@ Pretendard에서는 웹폰트 용량 문제를 해결하기 위한 방법으로 
 ###### cdnjs
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/variable/pretendardvariable.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/variable/pretendardvariable.css" />
 ```
 
 ###### UNPKG
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.1/dist/web/variable/pretendardvariable.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.2/dist/web/variable/pretendardvariable.css" />
 ```
 
 </details>
@@ -175,13 +175,13 @@ Pretendard에서는 웹폰트 용량 문제를 해결하기 위한 방법으로 
 ###### cdnjs
 
 ```css
-@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/variable/pretendardvariable.css');
+@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/variable/pretendardvariable.css');
 ```
 
 ###### UNPKG
 
 ```css
-@import url('https://unpkg.com/pretendard@1.3.1/dist/web/variable/pretendardvariable.css');
+@import url('https://unpkg.com/pretendard@1.3.2/dist/web/variable/pretendardvariable.css');
 ```
 
 </details>

--- a/dist/web/static/Pretendard-Black.css
+++ b/dist/web/static/Pretendard-Black.css
@@ -815,7 +815,7 @@
 	font-display: swap;
 	font-weight: 900;
 	src: url(./woff2-dynamic-subset/Pretendard-Black.subset.90.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-Black.subset.90.woff) format('woff');
-	unicode-range: U+39, U+49, U+4d-4e, U+ac04, U+ac1c, U+ac70, U+ac8c, U+acbd, U+acf5, U+acfc, U+ad00, U+ad6c, U+adf8, U+b098, U+b0b4, U+b294, U+b2c8, U+b300, U+b3c4, U+b3d9, U+b4dc, U+b4e4, U+b77c, U+b7ec, U+b85d, U+b97c, U+b9c8, U+b9cc, U+ba54, U+ba74, U+ba85, U+baa8, U+bb34, U+bb38, U+bbf8, U+bc14, U+bc29, U+bc88, U+bcf4, U+bd80, U+be44, U+c0c1, U+c11c, U+c120, U+c131, U+c138, U+c18c, U+c218, U+c2b5, U+c2e0, U+c544, U+c548, U+c5b4, U+c5d0, U+c5ec, U+c5f0, U+c601, U+c624, U+c694, U+c6a9, U+c6b0, U+c6b4, U+c6d0, U+c704, U+c720, U+c73c, U+c740, U+c744, U+c74c, U+c758, U+c77c, U+c785, U+c788, U+c790-c791, U+c7a5, U+c804, U+c815, U+c81c, U+c870, U+c8fc, U+c911, U+c9c4, U+ccb4, U+ce58, U+ce74, U+d06c, U+d0c0, U+d130, U+d2b8, U+d3ec, U+d504, U+d55c, U+d569, U+d574, U+d638, U+d654, U+d68c;
+	unicode-range: U+39, U+49, U+4d-4e, U+a0, U+ac04, U+ac1c, U+ac70, U+ac8c, U+acbd, U+acf5, U+acfc, U+ad00, U+ad6c, U+adf8, U+b098, U+b0b4, U+b294, U+b2c8, U+b300, U+b3c4, U+b3d9, U+b4dc, U+b4e4, U+b77c, U+b7ec, U+b85d, U+b97c, U+b9c8, U+b9cc, U+ba54, U+ba74, U+ba85, U+baa8, U+bb34, U+bb38, U+bbf8, U+bc14, U+bc29, U+bc88, U+bcf4, U+bd80, U+be44, U+c0c1, U+c11c, U+c120, U+c131, U+c138, U+c18c, U+c218, U+c2b5, U+c2e0, U+c544, U+c548, U+c5b4, U+c5d0, U+c5ec, U+c5f0, U+c601, U+c624, U+c694, U+c6a9, U+c6b0, U+c6b4, U+c6d0, U+c704, U+c720, U+c73c, U+c740, U+c744, U+c74c, U+c758, U+c77c, U+c785, U+c788, U+c790-c791, U+c7a5, U+c804, U+c815, U+c81c, U+c870, U+c8fc, U+c911, U+c9c4, U+ccb4, U+ce58, U+ce74, U+d06c, U+d0c0, U+d130, U+d2b8, U+d3ec, U+d504, U+d55c, U+d569, U+d574, U+d638, U+d654, U+d68c;
 }
 /* [91] */
 @font-face {
@@ -825,13 +825,4 @@
 	font-weight: 900;
 	src: url(./woff2-dynamic-subset/Pretendard-Black.subset.91.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-Black.subset.91.woff) format('woff');
 	unicode-range: U+20-22, U+27-2a, U+2c-38, U+3a-3b, U+3f, U+41-47, U+4a-4c, U+4f-5d, U+61-7b, U+7d, U+a1, U+ab, U+ae, U+b7, U+bb, U+bf, U+2013-2014, U+201c-201d, U+2122, U+ac00, U+ace0, U+ae30, U+b2e4, U+b85c, U+b9ac, U+c0ac, U+c2a4, U+c2dc, U+c774, U+c778, U+c9c0, U+d558;
-}
-/* [92] */
-@font-face {
-	font-family: 'Pretendard';
-	font-style: normal;
-	font-display: swap;
-	font-weight: 900;
-	src: url(./woff2-dynamic-subset/Pretendard-Black.subset.92.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-Black.subset.92.woff) format('woff');
-	unicode-range: U+a0;
 }

--- a/dist/web/static/Pretendard-Bold.css
+++ b/dist/web/static/Pretendard-Bold.css
@@ -815,7 +815,7 @@
 	font-display: swap;
 	font-weight: 700;
 	src: url(./woff2-dynamic-subset/Pretendard-Bold.subset.90.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-Bold.subset.90.woff) format('woff');
-	unicode-range: U+39, U+49, U+4d-4e, U+ac04, U+ac1c, U+ac70, U+ac8c, U+acbd, U+acf5, U+acfc, U+ad00, U+ad6c, U+adf8, U+b098, U+b0b4, U+b294, U+b2c8, U+b300, U+b3c4, U+b3d9, U+b4dc, U+b4e4, U+b77c, U+b7ec, U+b85d, U+b97c, U+b9c8, U+b9cc, U+ba54, U+ba74, U+ba85, U+baa8, U+bb34, U+bb38, U+bbf8, U+bc14, U+bc29, U+bc88, U+bcf4, U+bd80, U+be44, U+c0c1, U+c11c, U+c120, U+c131, U+c138, U+c18c, U+c218, U+c2b5, U+c2e0, U+c544, U+c548, U+c5b4, U+c5d0, U+c5ec, U+c5f0, U+c601, U+c624, U+c694, U+c6a9, U+c6b0, U+c6b4, U+c6d0, U+c704, U+c720, U+c73c, U+c740, U+c744, U+c74c, U+c758, U+c77c, U+c785, U+c788, U+c790-c791, U+c7a5, U+c804, U+c815, U+c81c, U+c870, U+c8fc, U+c911, U+c9c4, U+ccb4, U+ce58, U+ce74, U+d06c, U+d0c0, U+d130, U+d2b8, U+d3ec, U+d504, U+d55c, U+d569, U+d574, U+d638, U+d654, U+d68c;
+	unicode-range: U+39, U+49, U+4d-4e, U+a0, U+ac04, U+ac1c, U+ac70, U+ac8c, U+acbd, U+acf5, U+acfc, U+ad00, U+ad6c, U+adf8, U+b098, U+b0b4, U+b294, U+b2c8, U+b300, U+b3c4, U+b3d9, U+b4dc, U+b4e4, U+b77c, U+b7ec, U+b85d, U+b97c, U+b9c8, U+b9cc, U+ba54, U+ba74, U+ba85, U+baa8, U+bb34, U+bb38, U+bbf8, U+bc14, U+bc29, U+bc88, U+bcf4, U+bd80, U+be44, U+c0c1, U+c11c, U+c120, U+c131, U+c138, U+c18c, U+c218, U+c2b5, U+c2e0, U+c544, U+c548, U+c5b4, U+c5d0, U+c5ec, U+c5f0, U+c601, U+c624, U+c694, U+c6a9, U+c6b0, U+c6b4, U+c6d0, U+c704, U+c720, U+c73c, U+c740, U+c744, U+c74c, U+c758, U+c77c, U+c785, U+c788, U+c790-c791, U+c7a5, U+c804, U+c815, U+c81c, U+c870, U+c8fc, U+c911, U+c9c4, U+ccb4, U+ce58, U+ce74, U+d06c, U+d0c0, U+d130, U+d2b8, U+d3ec, U+d504, U+d55c, U+d569, U+d574, U+d638, U+d654, U+d68c;
 }
 /* [91] */
 @font-face {
@@ -825,13 +825,4 @@
 	font-weight: 700;
 	src: url(./woff2-dynamic-subset/Pretendard-Bold.subset.91.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-Bold.subset.91.woff) format('woff');
 	unicode-range: U+20-22, U+27-2a, U+2c-38, U+3a-3b, U+3f, U+41-47, U+4a-4c, U+4f-5d, U+61-7b, U+7d, U+a1, U+ab, U+ae, U+b7, U+bb, U+bf, U+2013-2014, U+201c-201d, U+2122, U+ac00, U+ace0, U+ae30, U+b2e4, U+b85c, U+b9ac, U+c0ac, U+c2a4, U+c2dc, U+c774, U+c778, U+c9c0, U+d558;
-}
-/* [92] */
-@font-face {
-	font-family: 'Pretendard';
-	font-style: normal;
-	font-display: swap;
-	font-weight: 700;
-	src: url(./woff2-dynamic-subset/Pretendard-Bold.subset.92.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-Bold.subset.92.woff) format('woff');
-	unicode-range: U+a0;
 }

--- a/dist/web/static/Pretendard-ExtraBold.css
+++ b/dist/web/static/Pretendard-ExtraBold.css
@@ -815,7 +815,7 @@
 	font-display: swap;
 	font-weight: 800;
 	src: url(./woff2-dynamic-subset/Pretendard-ExtraBold.subset.90.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-ExtraBold.subset.90.woff) format('woff');
-	unicode-range: U+39, U+49, U+4d-4e, U+ac04, U+ac1c, U+ac70, U+ac8c, U+acbd, U+acf5, U+acfc, U+ad00, U+ad6c, U+adf8, U+b098, U+b0b4, U+b294, U+b2c8, U+b300, U+b3c4, U+b3d9, U+b4dc, U+b4e4, U+b77c, U+b7ec, U+b85d, U+b97c, U+b9c8, U+b9cc, U+ba54, U+ba74, U+ba85, U+baa8, U+bb34, U+bb38, U+bbf8, U+bc14, U+bc29, U+bc88, U+bcf4, U+bd80, U+be44, U+c0c1, U+c11c, U+c120, U+c131, U+c138, U+c18c, U+c218, U+c2b5, U+c2e0, U+c544, U+c548, U+c5b4, U+c5d0, U+c5ec, U+c5f0, U+c601, U+c624, U+c694, U+c6a9, U+c6b0, U+c6b4, U+c6d0, U+c704, U+c720, U+c73c, U+c740, U+c744, U+c74c, U+c758, U+c77c, U+c785, U+c788, U+c790-c791, U+c7a5, U+c804, U+c815, U+c81c, U+c870, U+c8fc, U+c911, U+c9c4, U+ccb4, U+ce58, U+ce74, U+d06c, U+d0c0, U+d130, U+d2b8, U+d3ec, U+d504, U+d55c, U+d569, U+d574, U+d638, U+d654, U+d68c;
+	unicode-range: U+39, U+49, U+4d-4e, U+a0, U+ac04, U+ac1c, U+ac70, U+ac8c, U+acbd, U+acf5, U+acfc, U+ad00, U+ad6c, U+adf8, U+b098, U+b0b4, U+b294, U+b2c8, U+b300, U+b3c4, U+b3d9, U+b4dc, U+b4e4, U+b77c, U+b7ec, U+b85d, U+b97c, U+b9c8, U+b9cc, U+ba54, U+ba74, U+ba85, U+baa8, U+bb34, U+bb38, U+bbf8, U+bc14, U+bc29, U+bc88, U+bcf4, U+bd80, U+be44, U+c0c1, U+c11c, U+c120, U+c131, U+c138, U+c18c, U+c218, U+c2b5, U+c2e0, U+c544, U+c548, U+c5b4, U+c5d0, U+c5ec, U+c5f0, U+c601, U+c624, U+c694, U+c6a9, U+c6b0, U+c6b4, U+c6d0, U+c704, U+c720, U+c73c, U+c740, U+c744, U+c74c, U+c758, U+c77c, U+c785, U+c788, U+c790-c791, U+c7a5, U+c804, U+c815, U+c81c, U+c870, U+c8fc, U+c911, U+c9c4, U+ccb4, U+ce58, U+ce74, U+d06c, U+d0c0, U+d130, U+d2b8, U+d3ec, U+d504, U+d55c, U+d569, U+d574, U+d638, U+d654, U+d68c;
 }
 /* [91] */
 @font-face {
@@ -825,13 +825,4 @@
 	font-weight: 800;
 	src: url(./woff2-dynamic-subset/Pretendard-ExtraBold.subset.91.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-ExtraBold.subset.91.woff) format('woff');
 	unicode-range: U+20-22, U+27-2a, U+2c-38, U+3a-3b, U+3f, U+41-47, U+4a-4c, U+4f-5d, U+61-7b, U+7d, U+a1, U+ab, U+ae, U+b7, U+bb, U+bf, U+2013-2014, U+201c-201d, U+2122, U+ac00, U+ace0, U+ae30, U+b2e4, U+b85c, U+b9ac, U+c0ac, U+c2a4, U+c2dc, U+c774, U+c778, U+c9c0, U+d558;
-}
-/* [92] */
-@font-face {
-	font-family: 'Pretendard';
-	font-style: normal;
-	font-display: swap;
-	font-weight: 800;
-	src: url(./woff2-dynamic-subset/Pretendard-ExtraBold.subset.92.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-ExtraBold.subset.92.woff) format('woff');
-	unicode-range: U+a0;
 }

--- a/dist/web/static/Pretendard-ExtraLight.css
+++ b/dist/web/static/Pretendard-ExtraLight.css
@@ -815,7 +815,7 @@
 	font-display: swap;
 	font-weight: 200;
 	src: url(./woff2-dynamic-subset/Pretendard-ExtraLight.subset.90.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-ExtraLight.subset.90.woff) format('woff');
-	unicode-range: U+39, U+49, U+4d-4e, U+ac04, U+ac1c, U+ac70, U+ac8c, U+acbd, U+acf5, U+acfc, U+ad00, U+ad6c, U+adf8, U+b098, U+b0b4, U+b294, U+b2c8, U+b300, U+b3c4, U+b3d9, U+b4dc, U+b4e4, U+b77c, U+b7ec, U+b85d, U+b97c, U+b9c8, U+b9cc, U+ba54, U+ba74, U+ba85, U+baa8, U+bb34, U+bb38, U+bbf8, U+bc14, U+bc29, U+bc88, U+bcf4, U+bd80, U+be44, U+c0c1, U+c11c, U+c120, U+c131, U+c138, U+c18c, U+c218, U+c2b5, U+c2e0, U+c544, U+c548, U+c5b4, U+c5d0, U+c5ec, U+c5f0, U+c601, U+c624, U+c694, U+c6a9, U+c6b0, U+c6b4, U+c6d0, U+c704, U+c720, U+c73c, U+c740, U+c744, U+c74c, U+c758, U+c77c, U+c785, U+c788, U+c790-c791, U+c7a5, U+c804, U+c815, U+c81c, U+c870, U+c8fc, U+c911, U+c9c4, U+ccb4, U+ce58, U+ce74, U+d06c, U+d0c0, U+d130, U+d2b8, U+d3ec, U+d504, U+d55c, U+d569, U+d574, U+d638, U+d654, U+d68c;
+	unicode-range: U+39, U+49, U+4d-4e, U+a0, U+ac04, U+ac1c, U+ac70, U+ac8c, U+acbd, U+acf5, U+acfc, U+ad00, U+ad6c, U+adf8, U+b098, U+b0b4, U+b294, U+b2c8, U+b300, U+b3c4, U+b3d9, U+b4dc, U+b4e4, U+b77c, U+b7ec, U+b85d, U+b97c, U+b9c8, U+b9cc, U+ba54, U+ba74, U+ba85, U+baa8, U+bb34, U+bb38, U+bbf8, U+bc14, U+bc29, U+bc88, U+bcf4, U+bd80, U+be44, U+c0c1, U+c11c, U+c120, U+c131, U+c138, U+c18c, U+c218, U+c2b5, U+c2e0, U+c544, U+c548, U+c5b4, U+c5d0, U+c5ec, U+c5f0, U+c601, U+c624, U+c694, U+c6a9, U+c6b0, U+c6b4, U+c6d0, U+c704, U+c720, U+c73c, U+c740, U+c744, U+c74c, U+c758, U+c77c, U+c785, U+c788, U+c790-c791, U+c7a5, U+c804, U+c815, U+c81c, U+c870, U+c8fc, U+c911, U+c9c4, U+ccb4, U+ce58, U+ce74, U+d06c, U+d0c0, U+d130, U+d2b8, U+d3ec, U+d504, U+d55c, U+d569, U+d574, U+d638, U+d654, U+d68c;
 }
 /* [91] */
 @font-face {
@@ -825,13 +825,4 @@
 	font-weight: 200;
 	src: url(./woff2-dynamic-subset/Pretendard-ExtraLight.subset.91.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-ExtraLight.subset.91.woff) format('woff');
 	unicode-range: U+20-22, U+27-2a, U+2c-38, U+3a-3b, U+3f, U+41-47, U+4a-4c, U+4f-5d, U+61-7b, U+7d, U+a1, U+ab, U+ae, U+b7, U+bb, U+bf, U+2013-2014, U+201c-201d, U+2122, U+ac00, U+ace0, U+ae30, U+b2e4, U+b85c, U+b9ac, U+c0ac, U+c2a4, U+c2dc, U+c774, U+c778, U+c9c0, U+d558;
-}
-/* [92] */
-@font-face {
-	font-family: 'Pretendard';
-	font-style: normal;
-	font-display: swap;
-	font-weight: 200;
-	src: url(./woff2-dynamic-subset/Pretendard-ExtraLight.subset.92.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-ExtraLight.subset.92.woff) format('woff');
-	unicode-range: U+a0;
 }

--- a/dist/web/static/Pretendard-Light.css
+++ b/dist/web/static/Pretendard-Light.css
@@ -815,7 +815,7 @@
 	font-display: swap;
 	font-weight: 300;
 	src: url(./woff2-dynamic-subset/Pretendard-Light.subset.90.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-Light.subset.90.woff) format('woff');
-	unicode-range: U+39, U+49, U+4d-4e, U+ac04, U+ac1c, U+ac70, U+ac8c, U+acbd, U+acf5, U+acfc, U+ad00, U+ad6c, U+adf8, U+b098, U+b0b4, U+b294, U+b2c8, U+b300, U+b3c4, U+b3d9, U+b4dc, U+b4e4, U+b77c, U+b7ec, U+b85d, U+b97c, U+b9c8, U+b9cc, U+ba54, U+ba74, U+ba85, U+baa8, U+bb34, U+bb38, U+bbf8, U+bc14, U+bc29, U+bc88, U+bcf4, U+bd80, U+be44, U+c0c1, U+c11c, U+c120, U+c131, U+c138, U+c18c, U+c218, U+c2b5, U+c2e0, U+c544, U+c548, U+c5b4, U+c5d0, U+c5ec, U+c5f0, U+c601, U+c624, U+c694, U+c6a9, U+c6b0, U+c6b4, U+c6d0, U+c704, U+c720, U+c73c, U+c740, U+c744, U+c74c, U+c758, U+c77c, U+c785, U+c788, U+c790-c791, U+c7a5, U+c804, U+c815, U+c81c, U+c870, U+c8fc, U+c911, U+c9c4, U+ccb4, U+ce58, U+ce74, U+d06c, U+d0c0, U+d130, U+d2b8, U+d3ec, U+d504, U+d55c, U+d569, U+d574, U+d638, U+d654, U+d68c;
+	unicode-range: U+39, U+49, U+4d-4e, U+a0, U+ac04, U+ac1c, U+ac70, U+ac8c, U+acbd, U+acf5, U+acfc, U+ad00, U+ad6c, U+adf8, U+b098, U+b0b4, U+b294, U+b2c8, U+b300, U+b3c4, U+b3d9, U+b4dc, U+b4e4, U+b77c, U+b7ec, U+b85d, U+b97c, U+b9c8, U+b9cc, U+ba54, U+ba74, U+ba85, U+baa8, U+bb34, U+bb38, U+bbf8, U+bc14, U+bc29, U+bc88, U+bcf4, U+bd80, U+be44, U+c0c1, U+c11c, U+c120, U+c131, U+c138, U+c18c, U+c218, U+c2b5, U+c2e0, U+c544, U+c548, U+c5b4, U+c5d0, U+c5ec, U+c5f0, U+c601, U+c624, U+c694, U+c6a9, U+c6b0, U+c6b4, U+c6d0, U+c704, U+c720, U+c73c, U+c740, U+c744, U+c74c, U+c758, U+c77c, U+c785, U+c788, U+c790-c791, U+c7a5, U+c804, U+c815, U+c81c, U+c870, U+c8fc, U+c911, U+c9c4, U+ccb4, U+ce58, U+ce74, U+d06c, U+d0c0, U+d130, U+d2b8, U+d3ec, U+d504, U+d55c, U+d569, U+d574, U+d638, U+d654, U+d68c;
 }
 /* [91] */
 @font-face {
@@ -825,13 +825,4 @@
 	font-weight: 300;
 	src: url(./woff2-dynamic-subset/Pretendard-Light.subset.91.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-Light.subset.91.woff) format('woff');
 	unicode-range: U+20-22, U+27-2a, U+2c-38, U+3a-3b, U+3f, U+41-47, U+4a-4c, U+4f-5d, U+61-7b, U+7d, U+a1, U+ab, U+ae, U+b7, U+bb, U+bf, U+2013-2014, U+201c-201d, U+2122, U+ac00, U+ace0, U+ae30, U+b2e4, U+b85c, U+b9ac, U+c0ac, U+c2a4, U+c2dc, U+c774, U+c778, U+c9c0, U+d558;
-}
-/* [92] */
-@font-face {
-	font-family: 'Pretendard';
-	font-style: normal;
-	font-display: swap;
-	font-weight: 300;
-	src: url(./woff2-dynamic-subset/Pretendard-Light.subset.92.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-Light.subset.92.woff) format('woff');
-	unicode-range: U+a0;
 }

--- a/dist/web/static/Pretendard-Medium.css
+++ b/dist/web/static/Pretendard-Medium.css
@@ -815,7 +815,7 @@
 	font-display: swap;
 	font-weight: 500;
 	src: url(./woff2-dynamic-subset/Pretendard-Medium.subset.90.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-Medium.subset.90.woff) format('woff');
-	unicode-range: U+39, U+49, U+4d-4e, U+ac04, U+ac1c, U+ac70, U+ac8c, U+acbd, U+acf5, U+acfc, U+ad00, U+ad6c, U+adf8, U+b098, U+b0b4, U+b294, U+b2c8, U+b300, U+b3c4, U+b3d9, U+b4dc, U+b4e4, U+b77c, U+b7ec, U+b85d, U+b97c, U+b9c8, U+b9cc, U+ba54, U+ba74, U+ba85, U+baa8, U+bb34, U+bb38, U+bbf8, U+bc14, U+bc29, U+bc88, U+bcf4, U+bd80, U+be44, U+c0c1, U+c11c, U+c120, U+c131, U+c138, U+c18c, U+c218, U+c2b5, U+c2e0, U+c544, U+c548, U+c5b4, U+c5d0, U+c5ec, U+c5f0, U+c601, U+c624, U+c694, U+c6a9, U+c6b0, U+c6b4, U+c6d0, U+c704, U+c720, U+c73c, U+c740, U+c744, U+c74c, U+c758, U+c77c, U+c785, U+c788, U+c790-c791, U+c7a5, U+c804, U+c815, U+c81c, U+c870, U+c8fc, U+c911, U+c9c4, U+ccb4, U+ce58, U+ce74, U+d06c, U+d0c0, U+d130, U+d2b8, U+d3ec, U+d504, U+d55c, U+d569, U+d574, U+d638, U+d654, U+d68c;
+	unicode-range: U+39, U+49, U+4d-4e, U+a0, U+ac04, U+ac1c, U+ac70, U+ac8c, U+acbd, U+acf5, U+acfc, U+ad00, U+ad6c, U+adf8, U+b098, U+b0b4, U+b294, U+b2c8, U+b300, U+b3c4, U+b3d9, U+b4dc, U+b4e4, U+b77c, U+b7ec, U+b85d, U+b97c, U+b9c8, U+b9cc, U+ba54, U+ba74, U+ba85, U+baa8, U+bb34, U+bb38, U+bbf8, U+bc14, U+bc29, U+bc88, U+bcf4, U+bd80, U+be44, U+c0c1, U+c11c, U+c120, U+c131, U+c138, U+c18c, U+c218, U+c2b5, U+c2e0, U+c544, U+c548, U+c5b4, U+c5d0, U+c5ec, U+c5f0, U+c601, U+c624, U+c694, U+c6a9, U+c6b0, U+c6b4, U+c6d0, U+c704, U+c720, U+c73c, U+c740, U+c744, U+c74c, U+c758, U+c77c, U+c785, U+c788, U+c790-c791, U+c7a5, U+c804, U+c815, U+c81c, U+c870, U+c8fc, U+c911, U+c9c4, U+ccb4, U+ce58, U+ce74, U+d06c, U+d0c0, U+d130, U+d2b8, U+d3ec, U+d504, U+d55c, U+d569, U+d574, U+d638, U+d654, U+d68c;
 }
 /* [91] */
 @font-face {
@@ -825,13 +825,4 @@
 	font-weight: 500;
 	src: url(./woff2-dynamic-subset/Pretendard-Medium.subset.91.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-Medium.subset.91.woff) format('woff');
 	unicode-range: U+20-22, U+27-2a, U+2c-38, U+3a-3b, U+3f, U+41-47, U+4a-4c, U+4f-5d, U+61-7b, U+7d, U+a1, U+ab, U+ae, U+b7, U+bb, U+bf, U+2013-2014, U+201c-201d, U+2122, U+ac00, U+ace0, U+ae30, U+b2e4, U+b85c, U+b9ac, U+c0ac, U+c2a4, U+c2dc, U+c774, U+c778, U+c9c0, U+d558;
-}
-/* [92] */
-@font-face {
-	font-family: 'Pretendard';
-	font-style: normal;
-	font-display: swap;
-	font-weight: 500;
-	src: url(./woff2-dynamic-subset/Pretendard-Medium.subset.92.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-Medium.subset.92.woff) format('woff');
-	unicode-range: U+a0;
 }

--- a/dist/web/static/Pretendard-Regular.css
+++ b/dist/web/static/Pretendard-Regular.css
@@ -815,7 +815,7 @@
 	font-display: swap;
 	font-weight: 400;
 	src: url(./woff2-dynamic-subset/Pretendard-Regular.subset.90.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-Regular.subset.90.woff) format('woff');
-	unicode-range: U+39, U+49, U+4d-4e, U+ac04, U+ac1c, U+ac70, U+ac8c, U+acbd, U+acf5, U+acfc, U+ad00, U+ad6c, U+adf8, U+b098, U+b0b4, U+b294, U+b2c8, U+b300, U+b3c4, U+b3d9, U+b4dc, U+b4e4, U+b77c, U+b7ec, U+b85d, U+b97c, U+b9c8, U+b9cc, U+ba54, U+ba74, U+ba85, U+baa8, U+bb34, U+bb38, U+bbf8, U+bc14, U+bc29, U+bc88, U+bcf4, U+bd80, U+be44, U+c0c1, U+c11c, U+c120, U+c131, U+c138, U+c18c, U+c218, U+c2b5, U+c2e0, U+c544, U+c548, U+c5b4, U+c5d0, U+c5ec, U+c5f0, U+c601, U+c624, U+c694, U+c6a9, U+c6b0, U+c6b4, U+c6d0, U+c704, U+c720, U+c73c, U+c740, U+c744, U+c74c, U+c758, U+c77c, U+c785, U+c788, U+c790-c791, U+c7a5, U+c804, U+c815, U+c81c, U+c870, U+c8fc, U+c911, U+c9c4, U+ccb4, U+ce58, U+ce74, U+d06c, U+d0c0, U+d130, U+d2b8, U+d3ec, U+d504, U+d55c, U+d569, U+d574, U+d638, U+d654, U+d68c;
+	unicode-range: U+39, U+49, U+4d-4e, U+a0, U+ac04, U+ac1c, U+ac70, U+ac8c, U+acbd, U+acf5, U+acfc, U+ad00, U+ad6c, U+adf8, U+b098, U+b0b4, U+b294, U+b2c8, U+b300, U+b3c4, U+b3d9, U+b4dc, U+b4e4, U+b77c, U+b7ec, U+b85d, U+b97c, U+b9c8, U+b9cc, U+ba54, U+ba74, U+ba85, U+baa8, U+bb34, U+bb38, U+bbf8, U+bc14, U+bc29, U+bc88, U+bcf4, U+bd80, U+be44, U+c0c1, U+c11c, U+c120, U+c131, U+c138, U+c18c, U+c218, U+c2b5, U+c2e0, U+c544, U+c548, U+c5b4, U+c5d0, U+c5ec, U+c5f0, U+c601, U+c624, U+c694, U+c6a9, U+c6b0, U+c6b4, U+c6d0, U+c704, U+c720, U+c73c, U+c740, U+c744, U+c74c, U+c758, U+c77c, U+c785, U+c788, U+c790-c791, U+c7a5, U+c804, U+c815, U+c81c, U+c870, U+c8fc, U+c911, U+c9c4, U+ccb4, U+ce58, U+ce74, U+d06c, U+d0c0, U+d130, U+d2b8, U+d3ec, U+d504, U+d55c, U+d569, U+d574, U+d638, U+d654, U+d68c;
 }
 /* [91] */
 @font-face {
@@ -825,13 +825,4 @@
 	font-weight: 400;
 	src: url(./woff2-dynamic-subset/Pretendard-Regular.subset.91.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-Regular.subset.91.woff) format('woff');
 	unicode-range: U+20-22, U+27-2a, U+2c-38, U+3a-3b, U+3f, U+41-47, U+4a-4c, U+4f-5d, U+61-7b, U+7d, U+a1, U+ab, U+ae, U+b7, U+bb, U+bf, U+2013-2014, U+201c-201d, U+2122, U+ac00, U+ace0, U+ae30, U+b2e4, U+b85c, U+b9ac, U+c0ac, U+c2a4, U+c2dc, U+c774, U+c778, U+c9c0, U+d558;
-}
-/* [92] */
-@font-face {
-	font-family: 'Pretendard';
-	font-style: normal;
-	font-display: swap;
-	font-weight: 400;
-	src: url(./woff2-dynamic-subset/Pretendard-Regular.subset.92.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-Regular.subset.92.woff) format('woff');
-	unicode-range: U+a0;
 }

--- a/dist/web/static/Pretendard-SemiBold.css
+++ b/dist/web/static/Pretendard-SemiBold.css
@@ -815,7 +815,7 @@
 	font-display: swap;
 	font-weight: 600;
 	src: url(./woff2-dynamic-subset/Pretendard-SemiBold.subset.90.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-SemiBold.subset.90.woff) format('woff');
-	unicode-range: U+39, U+49, U+4d-4e, U+ac04, U+ac1c, U+ac70, U+ac8c, U+acbd, U+acf5, U+acfc, U+ad00, U+ad6c, U+adf8, U+b098, U+b0b4, U+b294, U+b2c8, U+b300, U+b3c4, U+b3d9, U+b4dc, U+b4e4, U+b77c, U+b7ec, U+b85d, U+b97c, U+b9c8, U+b9cc, U+ba54, U+ba74, U+ba85, U+baa8, U+bb34, U+bb38, U+bbf8, U+bc14, U+bc29, U+bc88, U+bcf4, U+bd80, U+be44, U+c0c1, U+c11c, U+c120, U+c131, U+c138, U+c18c, U+c218, U+c2b5, U+c2e0, U+c544, U+c548, U+c5b4, U+c5d0, U+c5ec, U+c5f0, U+c601, U+c624, U+c694, U+c6a9, U+c6b0, U+c6b4, U+c6d0, U+c704, U+c720, U+c73c, U+c740, U+c744, U+c74c, U+c758, U+c77c, U+c785, U+c788, U+c790-c791, U+c7a5, U+c804, U+c815, U+c81c, U+c870, U+c8fc, U+c911, U+c9c4, U+ccb4, U+ce58, U+ce74, U+d06c, U+d0c0, U+d130, U+d2b8, U+d3ec, U+d504, U+d55c, U+d569, U+d574, U+d638, U+d654, U+d68c;
+	unicode-range: U+39, U+49, U+4d-4e, U+a0, U+ac04, U+ac1c, U+ac70, U+ac8c, U+acbd, U+acf5, U+acfc, U+ad00, U+ad6c, U+adf8, U+b098, U+b0b4, U+b294, U+b2c8, U+b300, U+b3c4, U+b3d9, U+b4dc, U+b4e4, U+b77c, U+b7ec, U+b85d, U+b97c, U+b9c8, U+b9cc, U+ba54, U+ba74, U+ba85, U+baa8, U+bb34, U+bb38, U+bbf8, U+bc14, U+bc29, U+bc88, U+bcf4, U+bd80, U+be44, U+c0c1, U+c11c, U+c120, U+c131, U+c138, U+c18c, U+c218, U+c2b5, U+c2e0, U+c544, U+c548, U+c5b4, U+c5d0, U+c5ec, U+c5f0, U+c601, U+c624, U+c694, U+c6a9, U+c6b0, U+c6b4, U+c6d0, U+c704, U+c720, U+c73c, U+c740, U+c744, U+c74c, U+c758, U+c77c, U+c785, U+c788, U+c790-c791, U+c7a5, U+c804, U+c815, U+c81c, U+c870, U+c8fc, U+c911, U+c9c4, U+ccb4, U+ce58, U+ce74, U+d06c, U+d0c0, U+d130, U+d2b8, U+d3ec, U+d504, U+d55c, U+d569, U+d574, U+d638, U+d654, U+d68c;
 }
 /* [91] */
 @font-face {
@@ -825,13 +825,4 @@
 	font-weight: 600;
 	src: url(./woff2-dynamic-subset/Pretendard-SemiBold.subset.91.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-SemiBold.subset.91.woff) format('woff');
 	unicode-range: U+20-22, U+27-2a, U+2c-38, U+3a-3b, U+3f, U+41-47, U+4a-4c, U+4f-5d, U+61-7b, U+7d, U+a1, U+ab, U+ae, U+b7, U+bb, U+bf, U+2013-2014, U+201c-201d, U+2122, U+ac00, U+ace0, U+ae30, U+b2e4, U+b85c, U+b9ac, U+c0ac, U+c2a4, U+c2dc, U+c774, U+c778, U+c9c0, U+d558;
-}
-/* [92] */
-@font-face {
-	font-family: 'Pretendard';
-	font-style: normal;
-	font-display: swap;
-	font-weight: 600;
-	src: url(./woff2-dynamic-subset/Pretendard-SemiBold.subset.92.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-SemiBold.subset.92.woff) format('woff');
-	unicode-range: U+a0;
 }

--- a/dist/web/static/Pretendard-Thin.css
+++ b/dist/web/static/Pretendard-Thin.css
@@ -815,7 +815,7 @@
 	font-display: swap;
 	font-weight: 100;
 	src: url(./woff2-dynamic-subset/Pretendard-Thin.subset.90.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-Thin.subset.90.woff) format('woff');
-	unicode-range: U+39, U+49, U+4d-4e, U+ac04, U+ac1c, U+ac70, U+ac8c, U+acbd, U+acf5, U+acfc, U+ad00, U+ad6c, U+adf8, U+b098, U+b0b4, U+b294, U+b2c8, U+b300, U+b3c4, U+b3d9, U+b4dc, U+b4e4, U+b77c, U+b7ec, U+b85d, U+b97c, U+b9c8, U+b9cc, U+ba54, U+ba74, U+ba85, U+baa8, U+bb34, U+bb38, U+bbf8, U+bc14, U+bc29, U+bc88, U+bcf4, U+bd80, U+be44, U+c0c1, U+c11c, U+c120, U+c131, U+c138, U+c18c, U+c218, U+c2b5, U+c2e0, U+c544, U+c548, U+c5b4, U+c5d0, U+c5ec, U+c5f0, U+c601, U+c624, U+c694, U+c6a9, U+c6b0, U+c6b4, U+c6d0, U+c704, U+c720, U+c73c, U+c740, U+c744, U+c74c, U+c758, U+c77c, U+c785, U+c788, U+c790-c791, U+c7a5, U+c804, U+c815, U+c81c, U+c870, U+c8fc, U+c911, U+c9c4, U+ccb4, U+ce58, U+ce74, U+d06c, U+d0c0, U+d130, U+d2b8, U+d3ec, U+d504, U+d55c, U+d569, U+d574, U+d638, U+d654, U+d68c;
+	unicode-range: U+39, U+49, U+4d-4e, U+a0, U+ac04, U+ac1c, U+ac70, U+ac8c, U+acbd, U+acf5, U+acfc, U+ad00, U+ad6c, U+adf8, U+b098, U+b0b4, U+b294, U+b2c8, U+b300, U+b3c4, U+b3d9, U+b4dc, U+b4e4, U+b77c, U+b7ec, U+b85d, U+b97c, U+b9c8, U+b9cc, U+ba54, U+ba74, U+ba85, U+baa8, U+bb34, U+bb38, U+bbf8, U+bc14, U+bc29, U+bc88, U+bcf4, U+bd80, U+be44, U+c0c1, U+c11c, U+c120, U+c131, U+c138, U+c18c, U+c218, U+c2b5, U+c2e0, U+c544, U+c548, U+c5b4, U+c5d0, U+c5ec, U+c5f0, U+c601, U+c624, U+c694, U+c6a9, U+c6b0, U+c6b4, U+c6d0, U+c704, U+c720, U+c73c, U+c740, U+c744, U+c74c, U+c758, U+c77c, U+c785, U+c788, U+c790-c791, U+c7a5, U+c804, U+c815, U+c81c, U+c870, U+c8fc, U+c911, U+c9c4, U+ccb4, U+ce58, U+ce74, U+d06c, U+d0c0, U+d130, U+d2b8, U+d3ec, U+d504, U+d55c, U+d569, U+d574, U+d638, U+d654, U+d68c;
 }
 /* [91] */
 @font-face {
@@ -825,13 +825,4 @@
 	font-weight: 100;
 	src: url(./woff2-dynamic-subset/Pretendard-Thin.subset.91.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-Thin.subset.91.woff) format('woff');
 	unicode-range: U+20-22, U+27-2a, U+2c-38, U+3a-3b, U+3f, U+41-47, U+4a-4c, U+4f-5d, U+61-7b, U+7d, U+a1, U+ab, U+ae, U+b7, U+bb, U+bf, U+2013-2014, U+201c-201d, U+2122, U+ac00, U+ace0, U+ae30, U+b2e4, U+b85c, U+b9ac, U+c0ac, U+c2a4, U+c2dc, U+c774, U+c778, U+c9c0, U+d558;
-}
-/* [92] */
-@font-face {
-	font-family: 'Pretendard';
-	font-style: normal;
-	font-display: swap;
-	font-weight: 100;
-	src: url(./woff2-dynamic-subset/Pretendard-Thin.subset.92.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-Thin.subset.92.woff) format('woff');
-	unicode-range: U+a0;
 }

--- a/dist/web/static/PretendardJP-Black.css
+++ b/dist/web/static/PretendardJP-Black.css
@@ -1049,7 +1049,7 @@
 	font-display: swap;
 	font-weight: 900;
 	src: url(./woff2-dynamic-subset/PretendardJP-Black.subset.116.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-Black.subset.116.woff) format('woff');
-	unicode-range: U+4e, U+3000, U+300c-300d, U+4e00, U+4e0a, U+4e2d, U+4e8b, U+4eba, U+4f1a, U+5165, U+5168, U+5185, U+51fa, U+5206, U+5229, U+524d, U+52d5, U+5408, U+554f, U+5831, U+5834, U+5927, U+5b9a, U+5e74, U+5f0f, U+60c5, U+65b0, U+65b9, U+6642, U+6700, U+672c, U+682a, U+6b63, U+6c17, U+7121, U+751f, U+7528, U+753b, U+76ee, U+793e, U+884c, U+898b, U+8a18, U+9593, U+95a2, U+ff01, U+ff08-ff09;
+	unicode-range: U+4e, U+a0, U+3000, U+300c-300d, U+4e00, U+4e0a, U+4e2d, U+4e8b, U+4eba, U+4f1a, U+5165, U+5168, U+5185, U+51fa, U+5206, U+5229, U+524d, U+52d5, U+5408, U+554f, U+5831, U+5834, U+5927, U+5b9a, U+5e74, U+5f0f, U+60c5, U+65b0, U+65b9, U+6642, U+6700, U+672c, U+682a, U+6b63, U+6c17, U+7121, U+751f, U+7528, U+753b, U+76ee, U+793e, U+884c, U+898b, U+8a18, U+9593, U+95a2, U+ff01, U+ff08-ff09;
 }
 /* [117] */
 @font-face {
@@ -1068,13 +1068,4 @@
 	font-weight: 900;
 	src: url(./woff2-dynamic-subset/PretendardJP-Black.subset.118.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-Black.subset.118.woff) format('woff');
 	unicode-range: U+20, U+2027, U+3001-3002, U+3041-307f, U+3081-308f, U+3091-3093, U+3099-309a, U+309d-309e, U+30a1-30e1, U+30e3-30ed, U+30ef-30f0, U+30f2-30f4, U+30fb-30fe, U+ff0c, U+ff0e;
-}
-/* [119] */
-@font-face {
-	font-family: 'Pretendard JP';
-	font-style: normal;
-	font-display: swap;
-	font-weight: 900;
-	src: url(./woff2-dynamic-subset/PretendardJP-Black.subset.119.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-Black.subset.119.woff) format('woff');
-	unicode-range: U+a0;
 }

--- a/dist/web/static/PretendardJP-Bold.css
+++ b/dist/web/static/PretendardJP-Bold.css
@@ -1049,7 +1049,7 @@
 	font-display: swap;
 	font-weight: 700;
 	src: url(./woff2-dynamic-subset/PretendardJP-Bold.subset.116.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-Bold.subset.116.woff) format('woff');
-	unicode-range: U+4e, U+3000, U+300c-300d, U+4e00, U+4e0a, U+4e2d, U+4e8b, U+4eba, U+4f1a, U+5165, U+5168, U+5185, U+51fa, U+5206, U+5229, U+524d, U+52d5, U+5408, U+554f, U+5831, U+5834, U+5927, U+5b9a, U+5e74, U+5f0f, U+60c5, U+65b0, U+65b9, U+6642, U+6700, U+672c, U+682a, U+6b63, U+6c17, U+7121, U+751f, U+7528, U+753b, U+76ee, U+793e, U+884c, U+898b, U+8a18, U+9593, U+95a2, U+ff01, U+ff08-ff09;
+	unicode-range: U+4e, U+a0, U+3000, U+300c-300d, U+4e00, U+4e0a, U+4e2d, U+4e8b, U+4eba, U+4f1a, U+5165, U+5168, U+5185, U+51fa, U+5206, U+5229, U+524d, U+52d5, U+5408, U+554f, U+5831, U+5834, U+5927, U+5b9a, U+5e74, U+5f0f, U+60c5, U+65b0, U+65b9, U+6642, U+6700, U+672c, U+682a, U+6b63, U+6c17, U+7121, U+751f, U+7528, U+753b, U+76ee, U+793e, U+884c, U+898b, U+8a18, U+9593, U+95a2, U+ff01, U+ff08-ff09;
 }
 /* [117] */
 @font-face {
@@ -1068,13 +1068,4 @@
 	font-weight: 700;
 	src: url(./woff2-dynamic-subset/PretendardJP-Bold.subset.118.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-Bold.subset.118.woff) format('woff');
 	unicode-range: U+20, U+2027, U+3001-3002, U+3041-307f, U+3081-308f, U+3091-3093, U+3099-309a, U+309d-309e, U+30a1-30e1, U+30e3-30ed, U+30ef-30f0, U+30f2-30f4, U+30fb-30fe, U+ff0c, U+ff0e;
-}
-/* [119] */
-@font-face {
-	font-family: 'Pretendard JP';
-	font-style: normal;
-	font-display: swap;
-	font-weight: 700;
-	src: url(./woff2-dynamic-subset/PretendardJP-Bold.subset.119.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-Bold.subset.119.woff) format('woff');
-	unicode-range: U+a0;
 }

--- a/dist/web/static/PretendardJP-ExtraBold.css
+++ b/dist/web/static/PretendardJP-ExtraBold.css
@@ -1049,7 +1049,7 @@
 	font-display: swap;
 	font-weight: 800;
 	src: url(./woff2-dynamic-subset/PretendardJP-ExtraBold.subset.116.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-ExtraBold.subset.116.woff) format('woff');
-	unicode-range: U+4e, U+3000, U+300c-300d, U+4e00, U+4e0a, U+4e2d, U+4e8b, U+4eba, U+4f1a, U+5165, U+5168, U+5185, U+51fa, U+5206, U+5229, U+524d, U+52d5, U+5408, U+554f, U+5831, U+5834, U+5927, U+5b9a, U+5e74, U+5f0f, U+60c5, U+65b0, U+65b9, U+6642, U+6700, U+672c, U+682a, U+6b63, U+6c17, U+7121, U+751f, U+7528, U+753b, U+76ee, U+793e, U+884c, U+898b, U+8a18, U+9593, U+95a2, U+ff01, U+ff08-ff09;
+	unicode-range: U+4e, U+a0, U+3000, U+300c-300d, U+4e00, U+4e0a, U+4e2d, U+4e8b, U+4eba, U+4f1a, U+5165, U+5168, U+5185, U+51fa, U+5206, U+5229, U+524d, U+52d5, U+5408, U+554f, U+5831, U+5834, U+5927, U+5b9a, U+5e74, U+5f0f, U+60c5, U+65b0, U+65b9, U+6642, U+6700, U+672c, U+682a, U+6b63, U+6c17, U+7121, U+751f, U+7528, U+753b, U+76ee, U+793e, U+884c, U+898b, U+8a18, U+9593, U+95a2, U+ff01, U+ff08-ff09;
 }
 /* [117] */
 @font-face {
@@ -1068,13 +1068,4 @@
 	font-weight: 800;
 	src: url(./woff2-dynamic-subset/PretendardJP-ExtraBold.subset.118.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-ExtraBold.subset.118.woff) format('woff');
 	unicode-range: U+20, U+2027, U+3001-3002, U+3041-307f, U+3081-308f, U+3091-3093, U+3099-309a, U+309d-309e, U+30a1-30e1, U+30e3-30ed, U+30ef-30f0, U+30f2-30f4, U+30fb-30fe, U+ff0c, U+ff0e;
-}
-/* [119] */
-@font-face {
-	font-family: 'Pretendard JP';
-	font-style: normal;
-	font-display: swap;
-	font-weight: 800;
-	src: url(./woff2-dynamic-subset/PretendardJP-ExtraBold.subset.119.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-ExtraBold.subset.119.woff) format('woff');
-	unicode-range: U+a0;
 }

--- a/dist/web/static/PretendardJP-ExtraLight.css
+++ b/dist/web/static/PretendardJP-ExtraLight.css
@@ -1049,7 +1049,7 @@
 	font-display: swap;
 	font-weight: 200;
 	src: url(./woff2-dynamic-subset/PretendardJP-ExtraLight.subset.116.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-ExtraLight.subset.116.woff) format('woff');
-	unicode-range: U+4e, U+3000, U+300c-300d, U+4e00, U+4e0a, U+4e2d, U+4e8b, U+4eba, U+4f1a, U+5165, U+5168, U+5185, U+51fa, U+5206, U+5229, U+524d, U+52d5, U+5408, U+554f, U+5831, U+5834, U+5927, U+5b9a, U+5e74, U+5f0f, U+60c5, U+65b0, U+65b9, U+6642, U+6700, U+672c, U+682a, U+6b63, U+6c17, U+7121, U+751f, U+7528, U+753b, U+76ee, U+793e, U+884c, U+898b, U+8a18, U+9593, U+95a2, U+ff01, U+ff08-ff09;
+	unicode-range: U+4e, U+a0, U+3000, U+300c-300d, U+4e00, U+4e0a, U+4e2d, U+4e8b, U+4eba, U+4f1a, U+5165, U+5168, U+5185, U+51fa, U+5206, U+5229, U+524d, U+52d5, U+5408, U+554f, U+5831, U+5834, U+5927, U+5b9a, U+5e74, U+5f0f, U+60c5, U+65b0, U+65b9, U+6642, U+6700, U+672c, U+682a, U+6b63, U+6c17, U+7121, U+751f, U+7528, U+753b, U+76ee, U+793e, U+884c, U+898b, U+8a18, U+9593, U+95a2, U+ff01, U+ff08-ff09;
 }
 /* [117] */
 @font-face {
@@ -1068,13 +1068,4 @@
 	font-weight: 200;
 	src: url(./woff2-dynamic-subset/PretendardJP-ExtraLight.subset.118.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-ExtraLight.subset.118.woff) format('woff');
 	unicode-range: U+20, U+2027, U+3001-3002, U+3041-307f, U+3081-308f, U+3091-3093, U+3099-309a, U+309d-309e, U+30a1-30e1, U+30e3-30ed, U+30ef-30f0, U+30f2-30f4, U+30fb-30fe, U+ff0c, U+ff0e;
-}
-/* [119] */
-@font-face {
-	font-family: 'Pretendard JP';
-	font-style: normal;
-	font-display: swap;
-	font-weight: 200;
-	src: url(./woff2-dynamic-subset/PretendardJP-ExtraLight.subset.119.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-ExtraLight.subset.119.woff) format('woff');
-	unicode-range: U+a0;
 }

--- a/dist/web/static/PretendardJP-Light.css
+++ b/dist/web/static/PretendardJP-Light.css
@@ -1049,7 +1049,7 @@
 	font-display: swap;
 	font-weight: 300;
 	src: url(./woff2-dynamic-subset/PretendardJP-Light.subset.116.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-Light.subset.116.woff) format('woff');
-	unicode-range: U+4e, U+3000, U+300c-300d, U+4e00, U+4e0a, U+4e2d, U+4e8b, U+4eba, U+4f1a, U+5165, U+5168, U+5185, U+51fa, U+5206, U+5229, U+524d, U+52d5, U+5408, U+554f, U+5831, U+5834, U+5927, U+5b9a, U+5e74, U+5f0f, U+60c5, U+65b0, U+65b9, U+6642, U+6700, U+672c, U+682a, U+6b63, U+6c17, U+7121, U+751f, U+7528, U+753b, U+76ee, U+793e, U+884c, U+898b, U+8a18, U+9593, U+95a2, U+ff01, U+ff08-ff09;
+	unicode-range: U+4e, U+a0, U+3000, U+300c-300d, U+4e00, U+4e0a, U+4e2d, U+4e8b, U+4eba, U+4f1a, U+5165, U+5168, U+5185, U+51fa, U+5206, U+5229, U+524d, U+52d5, U+5408, U+554f, U+5831, U+5834, U+5927, U+5b9a, U+5e74, U+5f0f, U+60c5, U+65b0, U+65b9, U+6642, U+6700, U+672c, U+682a, U+6b63, U+6c17, U+7121, U+751f, U+7528, U+753b, U+76ee, U+793e, U+884c, U+898b, U+8a18, U+9593, U+95a2, U+ff01, U+ff08-ff09;
 }
 /* [117] */
 @font-face {
@@ -1068,13 +1068,4 @@
 	font-weight: 300;
 	src: url(./woff2-dynamic-subset/PretendardJP-Light.subset.118.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-Light.subset.118.woff) format('woff');
 	unicode-range: U+20, U+2027, U+3001-3002, U+3041-307f, U+3081-308f, U+3091-3093, U+3099-309a, U+309d-309e, U+30a1-30e1, U+30e3-30ed, U+30ef-30f0, U+30f2-30f4, U+30fb-30fe, U+ff0c, U+ff0e;
-}
-/* [119] */
-@font-face {
-	font-family: 'Pretendard JP';
-	font-style: normal;
-	font-display: swap;
-	font-weight: 300;
-	src: url(./woff2-dynamic-subset/PretendardJP-Light.subset.119.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-Light.subset.119.woff) format('woff');
-	unicode-range: U+a0;
 }

--- a/dist/web/static/PretendardJP-Medium.css
+++ b/dist/web/static/PretendardJP-Medium.css
@@ -1049,7 +1049,7 @@
 	font-display: swap;
 	font-weight: 500;
 	src: url(./woff2-dynamic-subset/PretendardJP-Medium.subset.116.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-Medium.subset.116.woff) format('woff');
-	unicode-range: U+4e, U+3000, U+300c-300d, U+4e00, U+4e0a, U+4e2d, U+4e8b, U+4eba, U+4f1a, U+5165, U+5168, U+5185, U+51fa, U+5206, U+5229, U+524d, U+52d5, U+5408, U+554f, U+5831, U+5834, U+5927, U+5b9a, U+5e74, U+5f0f, U+60c5, U+65b0, U+65b9, U+6642, U+6700, U+672c, U+682a, U+6b63, U+6c17, U+7121, U+751f, U+7528, U+753b, U+76ee, U+793e, U+884c, U+898b, U+8a18, U+9593, U+95a2, U+ff01, U+ff08-ff09;
+	unicode-range: U+4e, U+a0, U+3000, U+300c-300d, U+4e00, U+4e0a, U+4e2d, U+4e8b, U+4eba, U+4f1a, U+5165, U+5168, U+5185, U+51fa, U+5206, U+5229, U+524d, U+52d5, U+5408, U+554f, U+5831, U+5834, U+5927, U+5b9a, U+5e74, U+5f0f, U+60c5, U+65b0, U+65b9, U+6642, U+6700, U+672c, U+682a, U+6b63, U+6c17, U+7121, U+751f, U+7528, U+753b, U+76ee, U+793e, U+884c, U+898b, U+8a18, U+9593, U+95a2, U+ff01, U+ff08-ff09;
 }
 /* [117] */
 @font-face {
@@ -1068,13 +1068,4 @@
 	font-weight: 500;
 	src: url(./woff2-dynamic-subset/PretendardJP-Medium.subset.118.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-Medium.subset.118.woff) format('woff');
 	unicode-range: U+20, U+2027, U+3001-3002, U+3041-307f, U+3081-308f, U+3091-3093, U+3099-309a, U+309d-309e, U+30a1-30e1, U+30e3-30ed, U+30ef-30f0, U+30f2-30f4, U+30fb-30fe, U+ff0c, U+ff0e;
-}
-/* [119] */
-@font-face {
-	font-family: 'Pretendard JP';
-	font-style: normal;
-	font-display: swap;
-	font-weight: 500;
-	src: url(./woff2-dynamic-subset/PretendardJP-Medium.subset.119.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-Medium.subset.119.woff) format('woff');
-	unicode-range: U+a0;
 }

--- a/dist/web/static/PretendardJP-Regular.css
+++ b/dist/web/static/PretendardJP-Regular.css
@@ -1049,7 +1049,7 @@
 	font-display: swap;
 	font-weight: 400;
 	src: url(./woff2-dynamic-subset/PretendardJP-Regular.subset.116.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-Regular.subset.116.woff) format('woff');
-	unicode-range: U+4e, U+3000, U+300c-300d, U+4e00, U+4e0a, U+4e2d, U+4e8b, U+4eba, U+4f1a, U+5165, U+5168, U+5185, U+51fa, U+5206, U+5229, U+524d, U+52d5, U+5408, U+554f, U+5831, U+5834, U+5927, U+5b9a, U+5e74, U+5f0f, U+60c5, U+65b0, U+65b9, U+6642, U+6700, U+672c, U+682a, U+6b63, U+6c17, U+7121, U+751f, U+7528, U+753b, U+76ee, U+793e, U+884c, U+898b, U+8a18, U+9593, U+95a2, U+ff01, U+ff08-ff09;
+	unicode-range: U+4e, U+a0, U+3000, U+300c-300d, U+4e00, U+4e0a, U+4e2d, U+4e8b, U+4eba, U+4f1a, U+5165, U+5168, U+5185, U+51fa, U+5206, U+5229, U+524d, U+52d5, U+5408, U+554f, U+5831, U+5834, U+5927, U+5b9a, U+5e74, U+5f0f, U+60c5, U+65b0, U+65b9, U+6642, U+6700, U+672c, U+682a, U+6b63, U+6c17, U+7121, U+751f, U+7528, U+753b, U+76ee, U+793e, U+884c, U+898b, U+8a18, U+9593, U+95a2, U+ff01, U+ff08-ff09;
 }
 /* [117] */
 @font-face {
@@ -1068,13 +1068,4 @@
 	font-weight: 400;
 	src: url(./woff2-dynamic-subset/PretendardJP-Regular.subset.118.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-Regular.subset.118.woff) format('woff');
 	unicode-range: U+20, U+2027, U+3001-3002, U+3041-307f, U+3081-308f, U+3091-3093, U+3099-309a, U+309d-309e, U+30a1-30e1, U+30e3-30ed, U+30ef-30f0, U+30f2-30f4, U+30fb-30fe, U+ff0c, U+ff0e;
-}
-/* [119] */
-@font-face {
-	font-family: 'Pretendard JP';
-	font-style: normal;
-	font-display: swap;
-	font-weight: 400;
-	src: url(./woff2-dynamic-subset/PretendardJP-Regular.subset.119.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-Regular.subset.119.woff) format('woff');
-	unicode-range: U+a0;
 }

--- a/dist/web/static/PretendardJP-SemiBold.css
+++ b/dist/web/static/PretendardJP-SemiBold.css
@@ -1049,7 +1049,7 @@
 	font-display: swap;
 	font-weight: 600;
 	src: url(./woff2-dynamic-subset/PretendardJP-SemiBold.subset.116.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-SemiBold.subset.116.woff) format('woff');
-	unicode-range: U+4e, U+3000, U+300c-300d, U+4e00, U+4e0a, U+4e2d, U+4e8b, U+4eba, U+4f1a, U+5165, U+5168, U+5185, U+51fa, U+5206, U+5229, U+524d, U+52d5, U+5408, U+554f, U+5831, U+5834, U+5927, U+5b9a, U+5e74, U+5f0f, U+60c5, U+65b0, U+65b9, U+6642, U+6700, U+672c, U+682a, U+6b63, U+6c17, U+7121, U+751f, U+7528, U+753b, U+76ee, U+793e, U+884c, U+898b, U+8a18, U+9593, U+95a2, U+ff01, U+ff08-ff09;
+	unicode-range: U+4e, U+a0, U+3000, U+300c-300d, U+4e00, U+4e0a, U+4e2d, U+4e8b, U+4eba, U+4f1a, U+5165, U+5168, U+5185, U+51fa, U+5206, U+5229, U+524d, U+52d5, U+5408, U+554f, U+5831, U+5834, U+5927, U+5b9a, U+5e74, U+5f0f, U+60c5, U+65b0, U+65b9, U+6642, U+6700, U+672c, U+682a, U+6b63, U+6c17, U+7121, U+751f, U+7528, U+753b, U+76ee, U+793e, U+884c, U+898b, U+8a18, U+9593, U+95a2, U+ff01, U+ff08-ff09;
 }
 /* [117] */
 @font-face {
@@ -1068,13 +1068,4 @@
 	font-weight: 600;
 	src: url(./woff2-dynamic-subset/PretendardJP-SemiBold.subset.118.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-SemiBold.subset.118.woff) format('woff');
 	unicode-range: U+20, U+2027, U+3001-3002, U+3041-307f, U+3081-308f, U+3091-3093, U+3099-309a, U+309d-309e, U+30a1-30e1, U+30e3-30ed, U+30ef-30f0, U+30f2-30f4, U+30fb-30fe, U+ff0c, U+ff0e;
-}
-/* [119] */
-@font-face {
-	font-family: 'Pretendard JP';
-	font-style: normal;
-	font-display: swap;
-	font-weight: 600;
-	src: url(./woff2-dynamic-subset/PretendardJP-SemiBold.subset.119.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-SemiBold.subset.119.woff) format('woff');
-	unicode-range: U+a0;
 }

--- a/dist/web/static/PretendardJP-Thin.css
+++ b/dist/web/static/PretendardJP-Thin.css
@@ -1049,7 +1049,7 @@
 	font-display: swap;
 	font-weight: 100;
 	src: url(./woff2-dynamic-subset/PretendardJP-Thin.subset.116.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-Thin.subset.116.woff) format('woff');
-	unicode-range: U+4e, U+3000, U+300c-300d, U+4e00, U+4e0a, U+4e2d, U+4e8b, U+4eba, U+4f1a, U+5165, U+5168, U+5185, U+51fa, U+5206, U+5229, U+524d, U+52d5, U+5408, U+554f, U+5831, U+5834, U+5927, U+5b9a, U+5e74, U+5f0f, U+60c5, U+65b0, U+65b9, U+6642, U+6700, U+672c, U+682a, U+6b63, U+6c17, U+7121, U+751f, U+7528, U+753b, U+76ee, U+793e, U+884c, U+898b, U+8a18, U+9593, U+95a2, U+ff01, U+ff08-ff09;
+	unicode-range: U+4e, U+a0, U+3000, U+300c-300d, U+4e00, U+4e0a, U+4e2d, U+4e8b, U+4eba, U+4f1a, U+5165, U+5168, U+5185, U+51fa, U+5206, U+5229, U+524d, U+52d5, U+5408, U+554f, U+5831, U+5834, U+5927, U+5b9a, U+5e74, U+5f0f, U+60c5, U+65b0, U+65b9, U+6642, U+6700, U+672c, U+682a, U+6b63, U+6c17, U+7121, U+751f, U+7528, U+753b, U+76ee, U+793e, U+884c, U+898b, U+8a18, U+9593, U+95a2, U+ff01, U+ff08-ff09;
 }
 /* [117] */
 @font-face {
@@ -1068,13 +1068,4 @@
 	font-weight: 100;
 	src: url(./woff2-dynamic-subset/PretendardJP-Thin.subset.118.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-Thin.subset.118.woff) format('woff');
 	unicode-range: U+20, U+2027, U+3001-3002, U+3041-307f, U+3081-308f, U+3091-3093, U+3099-309a, U+309d-309e, U+30a1-30e1, U+30e3-30ed, U+30ef-30f0, U+30f2-30f4, U+30fb-30fe, U+ff0c, U+ff0e;
-}
-/* [119] */
-@font-face {
-	font-family: 'Pretendard JP';
-	font-style: normal;
-	font-display: swap;
-	font-weight: 100;
-	src: url(./woff2-dynamic-subset/PretendardJP-Thin.subset.119.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-Thin.subset.119.woff) format('woff');
-	unicode-range: U+a0;
 }

--- a/dist/web/static/pretendard-dynamic-subset.css
+++ b/dist/web/static/pretendard-dynamic-subset.css
@@ -823,7 +823,7 @@ http://scripts.sil.org/OFL
 	font-display: swap;
 	font-weight: 100;
 	src: url(./woff2-dynamic-subset/Pretendard-Thin.subset.90.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-Thin.subset.90.woff) format('woff');
-	unicode-range: U+39, U+49, U+4d-4e, U+ac04, U+ac1c, U+ac70, U+ac8c, U+acbd, U+acf5, U+acfc, U+ad00, U+ad6c, U+adf8, U+b098, U+b0b4, U+b294, U+b2c8, U+b300, U+b3c4, U+b3d9, U+b4dc, U+b4e4, U+b77c, U+b7ec, U+b85d, U+b97c, U+b9c8, U+b9cc, U+ba54, U+ba74, U+ba85, U+baa8, U+bb34, U+bb38, U+bbf8, U+bc14, U+bc29, U+bc88, U+bcf4, U+bd80, U+be44, U+c0c1, U+c11c, U+c120, U+c131, U+c138, U+c18c, U+c218, U+c2b5, U+c2e0, U+c544, U+c548, U+c5b4, U+c5d0, U+c5ec, U+c5f0, U+c601, U+c624, U+c694, U+c6a9, U+c6b0, U+c6b4, U+c6d0, U+c704, U+c720, U+c73c, U+c740, U+c744, U+c74c, U+c758, U+c77c, U+c785, U+c788, U+c790-c791, U+c7a5, U+c804, U+c815, U+c81c, U+c870, U+c8fc, U+c911, U+c9c4, U+ccb4, U+ce58, U+ce74, U+d06c, U+d0c0, U+d130, U+d2b8, U+d3ec, U+d504, U+d55c, U+d569, U+d574, U+d638, U+d654, U+d68c;
+	unicode-range: U+39, U+49, U+4d-4e, U+a0, U+ac04, U+ac1c, U+ac70, U+ac8c, U+acbd, U+acf5, U+acfc, U+ad00, U+ad6c, U+adf8, U+b098, U+b0b4, U+b294, U+b2c8, U+b300, U+b3c4, U+b3d9, U+b4dc, U+b4e4, U+b77c, U+b7ec, U+b85d, U+b97c, U+b9c8, U+b9cc, U+ba54, U+ba74, U+ba85, U+baa8, U+bb34, U+bb38, U+bbf8, U+bc14, U+bc29, U+bc88, U+bcf4, U+bd80, U+be44, U+c0c1, U+c11c, U+c120, U+c131, U+c138, U+c18c, U+c218, U+c2b5, U+c2e0, U+c544, U+c548, U+c5b4, U+c5d0, U+c5ec, U+c5f0, U+c601, U+c624, U+c694, U+c6a9, U+c6b0, U+c6b4, U+c6d0, U+c704, U+c720, U+c73c, U+c740, U+c744, U+c74c, U+c758, U+c77c, U+c785, U+c788, U+c790-c791, U+c7a5, U+c804, U+c815, U+c81c, U+c870, U+c8fc, U+c911, U+c9c4, U+ccb4, U+ce58, U+ce74, U+d06c, U+d0c0, U+d130, U+d2b8, U+d3ec, U+d504, U+d55c, U+d569, U+d574, U+d638, U+d654, U+d68c;
 }
 /* [91] */
 @font-face {
@@ -833,15 +833,6 @@ http://scripts.sil.org/OFL
 	font-weight: 100;
 	src: url(./woff2-dynamic-subset/Pretendard-Thin.subset.91.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-Thin.subset.91.woff) format('woff');
 	unicode-range: U+20-22, U+27-2a, U+2c-38, U+3a-3b, U+3f, U+41-47, U+4a-4c, U+4f-5d, U+61-7b, U+7d, U+a1, U+ab, U+ae, U+b7, U+bb, U+bf, U+2013-2014, U+201c-201d, U+2122, U+ac00, U+ace0, U+ae30, U+b2e4, U+b85c, U+b9ac, U+c0ac, U+c2a4, U+c2dc, U+c774, U+c778, U+c9c0, U+d558;
-}
-/* [92] */
-@font-face {
-	font-family: 'Pretendard';
-	font-style: normal;
-	font-display: swap;
-	font-weight: 100;
-	src: url(./woff2-dynamic-subset/Pretendard-Thin.subset.92.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-Thin.subset.92.woff) format('woff');
-	unicode-range: U+a0;
 }
 /* [0] */
 @font-face {
@@ -1660,7 +1651,7 @@ http://scripts.sil.org/OFL
 	font-display: swap;
 	font-weight: 200;
 	src: url(./woff2-dynamic-subset/Pretendard-ExtraLight.subset.90.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-ExtraLight.subset.90.woff) format('woff');
-	unicode-range: U+39, U+49, U+4d-4e, U+ac04, U+ac1c, U+ac70, U+ac8c, U+acbd, U+acf5, U+acfc, U+ad00, U+ad6c, U+adf8, U+b098, U+b0b4, U+b294, U+b2c8, U+b300, U+b3c4, U+b3d9, U+b4dc, U+b4e4, U+b77c, U+b7ec, U+b85d, U+b97c, U+b9c8, U+b9cc, U+ba54, U+ba74, U+ba85, U+baa8, U+bb34, U+bb38, U+bbf8, U+bc14, U+bc29, U+bc88, U+bcf4, U+bd80, U+be44, U+c0c1, U+c11c, U+c120, U+c131, U+c138, U+c18c, U+c218, U+c2b5, U+c2e0, U+c544, U+c548, U+c5b4, U+c5d0, U+c5ec, U+c5f0, U+c601, U+c624, U+c694, U+c6a9, U+c6b0, U+c6b4, U+c6d0, U+c704, U+c720, U+c73c, U+c740, U+c744, U+c74c, U+c758, U+c77c, U+c785, U+c788, U+c790-c791, U+c7a5, U+c804, U+c815, U+c81c, U+c870, U+c8fc, U+c911, U+c9c4, U+ccb4, U+ce58, U+ce74, U+d06c, U+d0c0, U+d130, U+d2b8, U+d3ec, U+d504, U+d55c, U+d569, U+d574, U+d638, U+d654, U+d68c;
+	unicode-range: U+39, U+49, U+4d-4e, U+a0, U+ac04, U+ac1c, U+ac70, U+ac8c, U+acbd, U+acf5, U+acfc, U+ad00, U+ad6c, U+adf8, U+b098, U+b0b4, U+b294, U+b2c8, U+b300, U+b3c4, U+b3d9, U+b4dc, U+b4e4, U+b77c, U+b7ec, U+b85d, U+b97c, U+b9c8, U+b9cc, U+ba54, U+ba74, U+ba85, U+baa8, U+bb34, U+bb38, U+bbf8, U+bc14, U+bc29, U+bc88, U+bcf4, U+bd80, U+be44, U+c0c1, U+c11c, U+c120, U+c131, U+c138, U+c18c, U+c218, U+c2b5, U+c2e0, U+c544, U+c548, U+c5b4, U+c5d0, U+c5ec, U+c5f0, U+c601, U+c624, U+c694, U+c6a9, U+c6b0, U+c6b4, U+c6d0, U+c704, U+c720, U+c73c, U+c740, U+c744, U+c74c, U+c758, U+c77c, U+c785, U+c788, U+c790-c791, U+c7a5, U+c804, U+c815, U+c81c, U+c870, U+c8fc, U+c911, U+c9c4, U+ccb4, U+ce58, U+ce74, U+d06c, U+d0c0, U+d130, U+d2b8, U+d3ec, U+d504, U+d55c, U+d569, U+d574, U+d638, U+d654, U+d68c;
 }
 /* [91] */
 @font-face {
@@ -1670,15 +1661,6 @@ http://scripts.sil.org/OFL
 	font-weight: 200;
 	src: url(./woff2-dynamic-subset/Pretendard-ExtraLight.subset.91.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-ExtraLight.subset.91.woff) format('woff');
 	unicode-range: U+20-22, U+27-2a, U+2c-38, U+3a-3b, U+3f, U+41-47, U+4a-4c, U+4f-5d, U+61-7b, U+7d, U+a1, U+ab, U+ae, U+b7, U+bb, U+bf, U+2013-2014, U+201c-201d, U+2122, U+ac00, U+ace0, U+ae30, U+b2e4, U+b85c, U+b9ac, U+c0ac, U+c2a4, U+c2dc, U+c774, U+c778, U+c9c0, U+d558;
-}
-/* [92] */
-@font-face {
-	font-family: 'Pretendard';
-	font-style: normal;
-	font-display: swap;
-	font-weight: 200;
-	src: url(./woff2-dynamic-subset/Pretendard-ExtraLight.subset.92.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-ExtraLight.subset.92.woff) format('woff');
-	unicode-range: U+a0;
 }
 /* [0] */
 @font-face {
@@ -2497,7 +2479,7 @@ http://scripts.sil.org/OFL
 	font-display: swap;
 	font-weight: 300;
 	src: url(./woff2-dynamic-subset/Pretendard-Light.subset.90.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-Light.subset.90.woff) format('woff');
-	unicode-range: U+39, U+49, U+4d-4e, U+ac04, U+ac1c, U+ac70, U+ac8c, U+acbd, U+acf5, U+acfc, U+ad00, U+ad6c, U+adf8, U+b098, U+b0b4, U+b294, U+b2c8, U+b300, U+b3c4, U+b3d9, U+b4dc, U+b4e4, U+b77c, U+b7ec, U+b85d, U+b97c, U+b9c8, U+b9cc, U+ba54, U+ba74, U+ba85, U+baa8, U+bb34, U+bb38, U+bbf8, U+bc14, U+bc29, U+bc88, U+bcf4, U+bd80, U+be44, U+c0c1, U+c11c, U+c120, U+c131, U+c138, U+c18c, U+c218, U+c2b5, U+c2e0, U+c544, U+c548, U+c5b4, U+c5d0, U+c5ec, U+c5f0, U+c601, U+c624, U+c694, U+c6a9, U+c6b0, U+c6b4, U+c6d0, U+c704, U+c720, U+c73c, U+c740, U+c744, U+c74c, U+c758, U+c77c, U+c785, U+c788, U+c790-c791, U+c7a5, U+c804, U+c815, U+c81c, U+c870, U+c8fc, U+c911, U+c9c4, U+ccb4, U+ce58, U+ce74, U+d06c, U+d0c0, U+d130, U+d2b8, U+d3ec, U+d504, U+d55c, U+d569, U+d574, U+d638, U+d654, U+d68c;
+	unicode-range: U+39, U+49, U+4d-4e, U+a0, U+ac04, U+ac1c, U+ac70, U+ac8c, U+acbd, U+acf5, U+acfc, U+ad00, U+ad6c, U+adf8, U+b098, U+b0b4, U+b294, U+b2c8, U+b300, U+b3c4, U+b3d9, U+b4dc, U+b4e4, U+b77c, U+b7ec, U+b85d, U+b97c, U+b9c8, U+b9cc, U+ba54, U+ba74, U+ba85, U+baa8, U+bb34, U+bb38, U+bbf8, U+bc14, U+bc29, U+bc88, U+bcf4, U+bd80, U+be44, U+c0c1, U+c11c, U+c120, U+c131, U+c138, U+c18c, U+c218, U+c2b5, U+c2e0, U+c544, U+c548, U+c5b4, U+c5d0, U+c5ec, U+c5f0, U+c601, U+c624, U+c694, U+c6a9, U+c6b0, U+c6b4, U+c6d0, U+c704, U+c720, U+c73c, U+c740, U+c744, U+c74c, U+c758, U+c77c, U+c785, U+c788, U+c790-c791, U+c7a5, U+c804, U+c815, U+c81c, U+c870, U+c8fc, U+c911, U+c9c4, U+ccb4, U+ce58, U+ce74, U+d06c, U+d0c0, U+d130, U+d2b8, U+d3ec, U+d504, U+d55c, U+d569, U+d574, U+d638, U+d654, U+d68c;
 }
 /* [91] */
 @font-face {
@@ -2507,15 +2489,6 @@ http://scripts.sil.org/OFL
 	font-weight: 300;
 	src: url(./woff2-dynamic-subset/Pretendard-Light.subset.91.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-Light.subset.91.woff) format('woff');
 	unicode-range: U+20-22, U+27-2a, U+2c-38, U+3a-3b, U+3f, U+41-47, U+4a-4c, U+4f-5d, U+61-7b, U+7d, U+a1, U+ab, U+ae, U+b7, U+bb, U+bf, U+2013-2014, U+201c-201d, U+2122, U+ac00, U+ace0, U+ae30, U+b2e4, U+b85c, U+b9ac, U+c0ac, U+c2a4, U+c2dc, U+c774, U+c778, U+c9c0, U+d558;
-}
-/* [92] */
-@font-face {
-	font-family: 'Pretendard';
-	font-style: normal;
-	font-display: swap;
-	font-weight: 300;
-	src: url(./woff2-dynamic-subset/Pretendard-Light.subset.92.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-Light.subset.92.woff) format('woff');
-	unicode-range: U+a0;
 }
 /* [0] */
 @font-face {
@@ -3334,7 +3307,7 @@ http://scripts.sil.org/OFL
 	font-display: swap;
 	font-weight: 400;
 	src: url(./woff2-dynamic-subset/Pretendard-Regular.subset.90.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-Regular.subset.90.woff) format('woff');
-	unicode-range: U+39, U+49, U+4d-4e, U+ac04, U+ac1c, U+ac70, U+ac8c, U+acbd, U+acf5, U+acfc, U+ad00, U+ad6c, U+adf8, U+b098, U+b0b4, U+b294, U+b2c8, U+b300, U+b3c4, U+b3d9, U+b4dc, U+b4e4, U+b77c, U+b7ec, U+b85d, U+b97c, U+b9c8, U+b9cc, U+ba54, U+ba74, U+ba85, U+baa8, U+bb34, U+bb38, U+bbf8, U+bc14, U+bc29, U+bc88, U+bcf4, U+bd80, U+be44, U+c0c1, U+c11c, U+c120, U+c131, U+c138, U+c18c, U+c218, U+c2b5, U+c2e0, U+c544, U+c548, U+c5b4, U+c5d0, U+c5ec, U+c5f0, U+c601, U+c624, U+c694, U+c6a9, U+c6b0, U+c6b4, U+c6d0, U+c704, U+c720, U+c73c, U+c740, U+c744, U+c74c, U+c758, U+c77c, U+c785, U+c788, U+c790-c791, U+c7a5, U+c804, U+c815, U+c81c, U+c870, U+c8fc, U+c911, U+c9c4, U+ccb4, U+ce58, U+ce74, U+d06c, U+d0c0, U+d130, U+d2b8, U+d3ec, U+d504, U+d55c, U+d569, U+d574, U+d638, U+d654, U+d68c;
+	unicode-range: U+39, U+49, U+4d-4e, U+a0, U+ac04, U+ac1c, U+ac70, U+ac8c, U+acbd, U+acf5, U+acfc, U+ad00, U+ad6c, U+adf8, U+b098, U+b0b4, U+b294, U+b2c8, U+b300, U+b3c4, U+b3d9, U+b4dc, U+b4e4, U+b77c, U+b7ec, U+b85d, U+b97c, U+b9c8, U+b9cc, U+ba54, U+ba74, U+ba85, U+baa8, U+bb34, U+bb38, U+bbf8, U+bc14, U+bc29, U+bc88, U+bcf4, U+bd80, U+be44, U+c0c1, U+c11c, U+c120, U+c131, U+c138, U+c18c, U+c218, U+c2b5, U+c2e0, U+c544, U+c548, U+c5b4, U+c5d0, U+c5ec, U+c5f0, U+c601, U+c624, U+c694, U+c6a9, U+c6b0, U+c6b4, U+c6d0, U+c704, U+c720, U+c73c, U+c740, U+c744, U+c74c, U+c758, U+c77c, U+c785, U+c788, U+c790-c791, U+c7a5, U+c804, U+c815, U+c81c, U+c870, U+c8fc, U+c911, U+c9c4, U+ccb4, U+ce58, U+ce74, U+d06c, U+d0c0, U+d130, U+d2b8, U+d3ec, U+d504, U+d55c, U+d569, U+d574, U+d638, U+d654, U+d68c;
 }
 /* [91] */
 @font-face {
@@ -3344,15 +3317,6 @@ http://scripts.sil.org/OFL
 	font-weight: 400;
 	src: url(./woff2-dynamic-subset/Pretendard-Regular.subset.91.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-Regular.subset.91.woff) format('woff');
 	unicode-range: U+20-22, U+27-2a, U+2c-38, U+3a-3b, U+3f, U+41-47, U+4a-4c, U+4f-5d, U+61-7b, U+7d, U+a1, U+ab, U+ae, U+b7, U+bb, U+bf, U+2013-2014, U+201c-201d, U+2122, U+ac00, U+ace0, U+ae30, U+b2e4, U+b85c, U+b9ac, U+c0ac, U+c2a4, U+c2dc, U+c774, U+c778, U+c9c0, U+d558;
-}
-/* [92] */
-@font-face {
-	font-family: 'Pretendard';
-	font-style: normal;
-	font-display: swap;
-	font-weight: 400;
-	src: url(./woff2-dynamic-subset/Pretendard-Regular.subset.92.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-Regular.subset.92.woff) format('woff');
-	unicode-range: U+a0;
 }
 /* [0] */
 @font-face {
@@ -4171,7 +4135,7 @@ http://scripts.sil.org/OFL
 	font-display: swap;
 	font-weight: 500;
 	src: url(./woff2-dynamic-subset/Pretendard-Medium.subset.90.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-Medium.subset.90.woff) format('woff');
-	unicode-range: U+39, U+49, U+4d-4e, U+ac04, U+ac1c, U+ac70, U+ac8c, U+acbd, U+acf5, U+acfc, U+ad00, U+ad6c, U+adf8, U+b098, U+b0b4, U+b294, U+b2c8, U+b300, U+b3c4, U+b3d9, U+b4dc, U+b4e4, U+b77c, U+b7ec, U+b85d, U+b97c, U+b9c8, U+b9cc, U+ba54, U+ba74, U+ba85, U+baa8, U+bb34, U+bb38, U+bbf8, U+bc14, U+bc29, U+bc88, U+bcf4, U+bd80, U+be44, U+c0c1, U+c11c, U+c120, U+c131, U+c138, U+c18c, U+c218, U+c2b5, U+c2e0, U+c544, U+c548, U+c5b4, U+c5d0, U+c5ec, U+c5f0, U+c601, U+c624, U+c694, U+c6a9, U+c6b0, U+c6b4, U+c6d0, U+c704, U+c720, U+c73c, U+c740, U+c744, U+c74c, U+c758, U+c77c, U+c785, U+c788, U+c790-c791, U+c7a5, U+c804, U+c815, U+c81c, U+c870, U+c8fc, U+c911, U+c9c4, U+ccb4, U+ce58, U+ce74, U+d06c, U+d0c0, U+d130, U+d2b8, U+d3ec, U+d504, U+d55c, U+d569, U+d574, U+d638, U+d654, U+d68c;
+	unicode-range: U+39, U+49, U+4d-4e, U+a0, U+ac04, U+ac1c, U+ac70, U+ac8c, U+acbd, U+acf5, U+acfc, U+ad00, U+ad6c, U+adf8, U+b098, U+b0b4, U+b294, U+b2c8, U+b300, U+b3c4, U+b3d9, U+b4dc, U+b4e4, U+b77c, U+b7ec, U+b85d, U+b97c, U+b9c8, U+b9cc, U+ba54, U+ba74, U+ba85, U+baa8, U+bb34, U+bb38, U+bbf8, U+bc14, U+bc29, U+bc88, U+bcf4, U+bd80, U+be44, U+c0c1, U+c11c, U+c120, U+c131, U+c138, U+c18c, U+c218, U+c2b5, U+c2e0, U+c544, U+c548, U+c5b4, U+c5d0, U+c5ec, U+c5f0, U+c601, U+c624, U+c694, U+c6a9, U+c6b0, U+c6b4, U+c6d0, U+c704, U+c720, U+c73c, U+c740, U+c744, U+c74c, U+c758, U+c77c, U+c785, U+c788, U+c790-c791, U+c7a5, U+c804, U+c815, U+c81c, U+c870, U+c8fc, U+c911, U+c9c4, U+ccb4, U+ce58, U+ce74, U+d06c, U+d0c0, U+d130, U+d2b8, U+d3ec, U+d504, U+d55c, U+d569, U+d574, U+d638, U+d654, U+d68c;
 }
 /* [91] */
 @font-face {
@@ -4181,15 +4145,6 @@ http://scripts.sil.org/OFL
 	font-weight: 500;
 	src: url(./woff2-dynamic-subset/Pretendard-Medium.subset.91.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-Medium.subset.91.woff) format('woff');
 	unicode-range: U+20-22, U+27-2a, U+2c-38, U+3a-3b, U+3f, U+41-47, U+4a-4c, U+4f-5d, U+61-7b, U+7d, U+a1, U+ab, U+ae, U+b7, U+bb, U+bf, U+2013-2014, U+201c-201d, U+2122, U+ac00, U+ace0, U+ae30, U+b2e4, U+b85c, U+b9ac, U+c0ac, U+c2a4, U+c2dc, U+c774, U+c778, U+c9c0, U+d558;
-}
-/* [92] */
-@font-face {
-	font-family: 'Pretendard';
-	font-style: normal;
-	font-display: swap;
-	font-weight: 500;
-	src: url(./woff2-dynamic-subset/Pretendard-Medium.subset.92.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-Medium.subset.92.woff) format('woff');
-	unicode-range: U+a0;
 }
 /* [0] */
 @font-face {
@@ -5008,7 +4963,7 @@ http://scripts.sil.org/OFL
 	font-display: swap;
 	font-weight: 600;
 	src: url(./woff2-dynamic-subset/Pretendard-SemiBold.subset.90.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-SemiBold.subset.90.woff) format('woff');
-	unicode-range: U+39, U+49, U+4d-4e, U+ac04, U+ac1c, U+ac70, U+ac8c, U+acbd, U+acf5, U+acfc, U+ad00, U+ad6c, U+adf8, U+b098, U+b0b4, U+b294, U+b2c8, U+b300, U+b3c4, U+b3d9, U+b4dc, U+b4e4, U+b77c, U+b7ec, U+b85d, U+b97c, U+b9c8, U+b9cc, U+ba54, U+ba74, U+ba85, U+baa8, U+bb34, U+bb38, U+bbf8, U+bc14, U+bc29, U+bc88, U+bcf4, U+bd80, U+be44, U+c0c1, U+c11c, U+c120, U+c131, U+c138, U+c18c, U+c218, U+c2b5, U+c2e0, U+c544, U+c548, U+c5b4, U+c5d0, U+c5ec, U+c5f0, U+c601, U+c624, U+c694, U+c6a9, U+c6b0, U+c6b4, U+c6d0, U+c704, U+c720, U+c73c, U+c740, U+c744, U+c74c, U+c758, U+c77c, U+c785, U+c788, U+c790-c791, U+c7a5, U+c804, U+c815, U+c81c, U+c870, U+c8fc, U+c911, U+c9c4, U+ccb4, U+ce58, U+ce74, U+d06c, U+d0c0, U+d130, U+d2b8, U+d3ec, U+d504, U+d55c, U+d569, U+d574, U+d638, U+d654, U+d68c;
+	unicode-range: U+39, U+49, U+4d-4e, U+a0, U+ac04, U+ac1c, U+ac70, U+ac8c, U+acbd, U+acf5, U+acfc, U+ad00, U+ad6c, U+adf8, U+b098, U+b0b4, U+b294, U+b2c8, U+b300, U+b3c4, U+b3d9, U+b4dc, U+b4e4, U+b77c, U+b7ec, U+b85d, U+b97c, U+b9c8, U+b9cc, U+ba54, U+ba74, U+ba85, U+baa8, U+bb34, U+bb38, U+bbf8, U+bc14, U+bc29, U+bc88, U+bcf4, U+bd80, U+be44, U+c0c1, U+c11c, U+c120, U+c131, U+c138, U+c18c, U+c218, U+c2b5, U+c2e0, U+c544, U+c548, U+c5b4, U+c5d0, U+c5ec, U+c5f0, U+c601, U+c624, U+c694, U+c6a9, U+c6b0, U+c6b4, U+c6d0, U+c704, U+c720, U+c73c, U+c740, U+c744, U+c74c, U+c758, U+c77c, U+c785, U+c788, U+c790-c791, U+c7a5, U+c804, U+c815, U+c81c, U+c870, U+c8fc, U+c911, U+c9c4, U+ccb4, U+ce58, U+ce74, U+d06c, U+d0c0, U+d130, U+d2b8, U+d3ec, U+d504, U+d55c, U+d569, U+d574, U+d638, U+d654, U+d68c;
 }
 /* [91] */
 @font-face {
@@ -5018,15 +4973,6 @@ http://scripts.sil.org/OFL
 	font-weight: 600;
 	src: url(./woff2-dynamic-subset/Pretendard-SemiBold.subset.91.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-SemiBold.subset.91.woff) format('woff');
 	unicode-range: U+20-22, U+27-2a, U+2c-38, U+3a-3b, U+3f, U+41-47, U+4a-4c, U+4f-5d, U+61-7b, U+7d, U+a1, U+ab, U+ae, U+b7, U+bb, U+bf, U+2013-2014, U+201c-201d, U+2122, U+ac00, U+ace0, U+ae30, U+b2e4, U+b85c, U+b9ac, U+c0ac, U+c2a4, U+c2dc, U+c774, U+c778, U+c9c0, U+d558;
-}
-/* [92] */
-@font-face {
-	font-family: 'Pretendard';
-	font-style: normal;
-	font-display: swap;
-	font-weight: 600;
-	src: url(./woff2-dynamic-subset/Pretendard-SemiBold.subset.92.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-SemiBold.subset.92.woff) format('woff');
-	unicode-range: U+a0;
 }
 /* [0] */
 @font-face {
@@ -5845,7 +5791,7 @@ http://scripts.sil.org/OFL
 	font-display: swap;
 	font-weight: 700;
 	src: url(./woff2-dynamic-subset/Pretendard-Bold.subset.90.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-Bold.subset.90.woff) format('woff');
-	unicode-range: U+39, U+49, U+4d-4e, U+ac04, U+ac1c, U+ac70, U+ac8c, U+acbd, U+acf5, U+acfc, U+ad00, U+ad6c, U+adf8, U+b098, U+b0b4, U+b294, U+b2c8, U+b300, U+b3c4, U+b3d9, U+b4dc, U+b4e4, U+b77c, U+b7ec, U+b85d, U+b97c, U+b9c8, U+b9cc, U+ba54, U+ba74, U+ba85, U+baa8, U+bb34, U+bb38, U+bbf8, U+bc14, U+bc29, U+bc88, U+bcf4, U+bd80, U+be44, U+c0c1, U+c11c, U+c120, U+c131, U+c138, U+c18c, U+c218, U+c2b5, U+c2e0, U+c544, U+c548, U+c5b4, U+c5d0, U+c5ec, U+c5f0, U+c601, U+c624, U+c694, U+c6a9, U+c6b0, U+c6b4, U+c6d0, U+c704, U+c720, U+c73c, U+c740, U+c744, U+c74c, U+c758, U+c77c, U+c785, U+c788, U+c790-c791, U+c7a5, U+c804, U+c815, U+c81c, U+c870, U+c8fc, U+c911, U+c9c4, U+ccb4, U+ce58, U+ce74, U+d06c, U+d0c0, U+d130, U+d2b8, U+d3ec, U+d504, U+d55c, U+d569, U+d574, U+d638, U+d654, U+d68c;
+	unicode-range: U+39, U+49, U+4d-4e, U+a0, U+ac04, U+ac1c, U+ac70, U+ac8c, U+acbd, U+acf5, U+acfc, U+ad00, U+ad6c, U+adf8, U+b098, U+b0b4, U+b294, U+b2c8, U+b300, U+b3c4, U+b3d9, U+b4dc, U+b4e4, U+b77c, U+b7ec, U+b85d, U+b97c, U+b9c8, U+b9cc, U+ba54, U+ba74, U+ba85, U+baa8, U+bb34, U+bb38, U+bbf8, U+bc14, U+bc29, U+bc88, U+bcf4, U+bd80, U+be44, U+c0c1, U+c11c, U+c120, U+c131, U+c138, U+c18c, U+c218, U+c2b5, U+c2e0, U+c544, U+c548, U+c5b4, U+c5d0, U+c5ec, U+c5f0, U+c601, U+c624, U+c694, U+c6a9, U+c6b0, U+c6b4, U+c6d0, U+c704, U+c720, U+c73c, U+c740, U+c744, U+c74c, U+c758, U+c77c, U+c785, U+c788, U+c790-c791, U+c7a5, U+c804, U+c815, U+c81c, U+c870, U+c8fc, U+c911, U+c9c4, U+ccb4, U+ce58, U+ce74, U+d06c, U+d0c0, U+d130, U+d2b8, U+d3ec, U+d504, U+d55c, U+d569, U+d574, U+d638, U+d654, U+d68c;
 }
 /* [91] */
 @font-face {
@@ -5855,15 +5801,6 @@ http://scripts.sil.org/OFL
 	font-weight: 700;
 	src: url(./woff2-dynamic-subset/Pretendard-Bold.subset.91.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-Bold.subset.91.woff) format('woff');
 	unicode-range: U+20-22, U+27-2a, U+2c-38, U+3a-3b, U+3f, U+41-47, U+4a-4c, U+4f-5d, U+61-7b, U+7d, U+a1, U+ab, U+ae, U+b7, U+bb, U+bf, U+2013-2014, U+201c-201d, U+2122, U+ac00, U+ace0, U+ae30, U+b2e4, U+b85c, U+b9ac, U+c0ac, U+c2a4, U+c2dc, U+c774, U+c778, U+c9c0, U+d558;
-}
-/* [92] */
-@font-face {
-	font-family: 'Pretendard';
-	font-style: normal;
-	font-display: swap;
-	font-weight: 700;
-	src: url(./woff2-dynamic-subset/Pretendard-Bold.subset.92.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-Bold.subset.92.woff) format('woff');
-	unicode-range: U+a0;
 }
 /* [0] */
 @font-face {
@@ -6682,7 +6619,7 @@ http://scripts.sil.org/OFL
 	font-display: swap;
 	font-weight: 800;
 	src: url(./woff2-dynamic-subset/Pretendard-ExtraBold.subset.90.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-ExtraBold.subset.90.woff) format('woff');
-	unicode-range: U+39, U+49, U+4d-4e, U+ac04, U+ac1c, U+ac70, U+ac8c, U+acbd, U+acf5, U+acfc, U+ad00, U+ad6c, U+adf8, U+b098, U+b0b4, U+b294, U+b2c8, U+b300, U+b3c4, U+b3d9, U+b4dc, U+b4e4, U+b77c, U+b7ec, U+b85d, U+b97c, U+b9c8, U+b9cc, U+ba54, U+ba74, U+ba85, U+baa8, U+bb34, U+bb38, U+bbf8, U+bc14, U+bc29, U+bc88, U+bcf4, U+bd80, U+be44, U+c0c1, U+c11c, U+c120, U+c131, U+c138, U+c18c, U+c218, U+c2b5, U+c2e0, U+c544, U+c548, U+c5b4, U+c5d0, U+c5ec, U+c5f0, U+c601, U+c624, U+c694, U+c6a9, U+c6b0, U+c6b4, U+c6d0, U+c704, U+c720, U+c73c, U+c740, U+c744, U+c74c, U+c758, U+c77c, U+c785, U+c788, U+c790-c791, U+c7a5, U+c804, U+c815, U+c81c, U+c870, U+c8fc, U+c911, U+c9c4, U+ccb4, U+ce58, U+ce74, U+d06c, U+d0c0, U+d130, U+d2b8, U+d3ec, U+d504, U+d55c, U+d569, U+d574, U+d638, U+d654, U+d68c;
+	unicode-range: U+39, U+49, U+4d-4e, U+a0, U+ac04, U+ac1c, U+ac70, U+ac8c, U+acbd, U+acf5, U+acfc, U+ad00, U+ad6c, U+adf8, U+b098, U+b0b4, U+b294, U+b2c8, U+b300, U+b3c4, U+b3d9, U+b4dc, U+b4e4, U+b77c, U+b7ec, U+b85d, U+b97c, U+b9c8, U+b9cc, U+ba54, U+ba74, U+ba85, U+baa8, U+bb34, U+bb38, U+bbf8, U+bc14, U+bc29, U+bc88, U+bcf4, U+bd80, U+be44, U+c0c1, U+c11c, U+c120, U+c131, U+c138, U+c18c, U+c218, U+c2b5, U+c2e0, U+c544, U+c548, U+c5b4, U+c5d0, U+c5ec, U+c5f0, U+c601, U+c624, U+c694, U+c6a9, U+c6b0, U+c6b4, U+c6d0, U+c704, U+c720, U+c73c, U+c740, U+c744, U+c74c, U+c758, U+c77c, U+c785, U+c788, U+c790-c791, U+c7a5, U+c804, U+c815, U+c81c, U+c870, U+c8fc, U+c911, U+c9c4, U+ccb4, U+ce58, U+ce74, U+d06c, U+d0c0, U+d130, U+d2b8, U+d3ec, U+d504, U+d55c, U+d569, U+d574, U+d638, U+d654, U+d68c;
 }
 /* [91] */
 @font-face {
@@ -6692,15 +6629,6 @@ http://scripts.sil.org/OFL
 	font-weight: 800;
 	src: url(./woff2-dynamic-subset/Pretendard-ExtraBold.subset.91.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-ExtraBold.subset.91.woff) format('woff');
 	unicode-range: U+20-22, U+27-2a, U+2c-38, U+3a-3b, U+3f, U+41-47, U+4a-4c, U+4f-5d, U+61-7b, U+7d, U+a1, U+ab, U+ae, U+b7, U+bb, U+bf, U+2013-2014, U+201c-201d, U+2122, U+ac00, U+ace0, U+ae30, U+b2e4, U+b85c, U+b9ac, U+c0ac, U+c2a4, U+c2dc, U+c774, U+c778, U+c9c0, U+d558;
-}
-/* [92] */
-@font-face {
-	font-family: 'Pretendard';
-	font-style: normal;
-	font-display: swap;
-	font-weight: 800;
-	src: url(./woff2-dynamic-subset/Pretendard-ExtraBold.subset.92.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-ExtraBold.subset.92.woff) format('woff');
-	unicode-range: U+a0;
 }
 /* [0] */
 @font-face {
@@ -7519,7 +7447,7 @@ http://scripts.sil.org/OFL
 	font-display: swap;
 	font-weight: 900;
 	src: url(./woff2-dynamic-subset/Pretendard-Black.subset.90.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-Black.subset.90.woff) format('woff');
-	unicode-range: U+39, U+49, U+4d-4e, U+ac04, U+ac1c, U+ac70, U+ac8c, U+acbd, U+acf5, U+acfc, U+ad00, U+ad6c, U+adf8, U+b098, U+b0b4, U+b294, U+b2c8, U+b300, U+b3c4, U+b3d9, U+b4dc, U+b4e4, U+b77c, U+b7ec, U+b85d, U+b97c, U+b9c8, U+b9cc, U+ba54, U+ba74, U+ba85, U+baa8, U+bb34, U+bb38, U+bbf8, U+bc14, U+bc29, U+bc88, U+bcf4, U+bd80, U+be44, U+c0c1, U+c11c, U+c120, U+c131, U+c138, U+c18c, U+c218, U+c2b5, U+c2e0, U+c544, U+c548, U+c5b4, U+c5d0, U+c5ec, U+c5f0, U+c601, U+c624, U+c694, U+c6a9, U+c6b0, U+c6b4, U+c6d0, U+c704, U+c720, U+c73c, U+c740, U+c744, U+c74c, U+c758, U+c77c, U+c785, U+c788, U+c790-c791, U+c7a5, U+c804, U+c815, U+c81c, U+c870, U+c8fc, U+c911, U+c9c4, U+ccb4, U+ce58, U+ce74, U+d06c, U+d0c0, U+d130, U+d2b8, U+d3ec, U+d504, U+d55c, U+d569, U+d574, U+d638, U+d654, U+d68c;
+	unicode-range: U+39, U+49, U+4d-4e, U+a0, U+ac04, U+ac1c, U+ac70, U+ac8c, U+acbd, U+acf5, U+acfc, U+ad00, U+ad6c, U+adf8, U+b098, U+b0b4, U+b294, U+b2c8, U+b300, U+b3c4, U+b3d9, U+b4dc, U+b4e4, U+b77c, U+b7ec, U+b85d, U+b97c, U+b9c8, U+b9cc, U+ba54, U+ba74, U+ba85, U+baa8, U+bb34, U+bb38, U+bbf8, U+bc14, U+bc29, U+bc88, U+bcf4, U+bd80, U+be44, U+c0c1, U+c11c, U+c120, U+c131, U+c138, U+c18c, U+c218, U+c2b5, U+c2e0, U+c544, U+c548, U+c5b4, U+c5d0, U+c5ec, U+c5f0, U+c601, U+c624, U+c694, U+c6a9, U+c6b0, U+c6b4, U+c6d0, U+c704, U+c720, U+c73c, U+c740, U+c744, U+c74c, U+c758, U+c77c, U+c785, U+c788, U+c790-c791, U+c7a5, U+c804, U+c815, U+c81c, U+c870, U+c8fc, U+c911, U+c9c4, U+ccb4, U+ce58, U+ce74, U+d06c, U+d0c0, U+d130, U+d2b8, U+d3ec, U+d504, U+d55c, U+d569, U+d574, U+d638, U+d654, U+d68c;
 }
 /* [91] */
 @font-face {
@@ -7529,13 +7457,4 @@ http://scripts.sil.org/OFL
 	font-weight: 900;
 	src: url(./woff2-dynamic-subset/Pretendard-Black.subset.91.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-Black.subset.91.woff) format('woff');
 	unicode-range: U+20-22, U+27-2a, U+2c-38, U+3a-3b, U+3f, U+41-47, U+4a-4c, U+4f-5d, U+61-7b, U+7d, U+a1, U+ab, U+ae, U+b7, U+bb, U+bf, U+2013-2014, U+201c-201d, U+2122, U+ac00, U+ace0, U+ae30, U+b2e4, U+b85c, U+b9ac, U+c0ac, U+c2a4, U+c2dc, U+c774, U+c778, U+c9c0, U+d558;
-}
-/* [92] */
-@font-face {
-	font-family: 'Pretendard';
-	font-style: normal;
-	font-display: swap;
-	font-weight: 900;
-	src: url(./woff2-dynamic-subset/Pretendard-Black.subset.92.woff2) format('woff2'), url(./woff-dynamic-subset/Pretendard-Black.subset.92.woff) format('woff');
-	unicode-range: U+a0;
 }

--- a/dist/web/static/pretendard-jp-dynamic-subset.css
+++ b/dist/web/static/pretendard-jp-dynamic-subset.css
@@ -1057,7 +1057,7 @@ http://scripts.sil.org/OFL
 	font-display: swap;
 	font-weight: 100;
 	src: url(./woff2-dynamic-subset/PretendardJP-Thin.subset.116.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-Thin.subset.116.woff) format('woff');
-	unicode-range: U+4e, U+3000, U+300c-300d, U+4e00, U+4e0a, U+4e2d, U+4e8b, U+4eba, U+4f1a, U+5165, U+5168, U+5185, U+51fa, U+5206, U+5229, U+524d, U+52d5, U+5408, U+554f, U+5831, U+5834, U+5927, U+5b9a, U+5e74, U+5f0f, U+60c5, U+65b0, U+65b9, U+6642, U+6700, U+672c, U+682a, U+6b63, U+6c17, U+7121, U+751f, U+7528, U+753b, U+76ee, U+793e, U+884c, U+898b, U+8a18, U+9593, U+95a2, U+ff01, U+ff08-ff09;
+	unicode-range: U+4e, U+a0, U+3000, U+300c-300d, U+4e00, U+4e0a, U+4e2d, U+4e8b, U+4eba, U+4f1a, U+5165, U+5168, U+5185, U+51fa, U+5206, U+5229, U+524d, U+52d5, U+5408, U+554f, U+5831, U+5834, U+5927, U+5b9a, U+5e74, U+5f0f, U+60c5, U+65b0, U+65b9, U+6642, U+6700, U+672c, U+682a, U+6b63, U+6c17, U+7121, U+751f, U+7528, U+753b, U+76ee, U+793e, U+884c, U+898b, U+8a18, U+9593, U+95a2, U+ff01, U+ff08-ff09;
 }
 /* [117] */
 @font-face {
@@ -1076,15 +1076,6 @@ http://scripts.sil.org/OFL
 	font-weight: 100;
 	src: url(./woff2-dynamic-subset/PretendardJP-Thin.subset.118.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-Thin.subset.118.woff) format('woff');
 	unicode-range: U+20, U+2027, U+3001-3002, U+3041-307f, U+3081-308f, U+3091-3093, U+3099-309a, U+309d-309e, U+30a1-30e1, U+30e3-30ed, U+30ef-30f0, U+30f2-30f4, U+30fb-30fe, U+ff0c, U+ff0e;
-}
-/* [119] */
-@font-face {
-	font-family: 'Pretendard JP';
-	font-style: normal;
-	font-display: swap;
-	font-weight: 100;
-	src: url(./woff2-dynamic-subset/PretendardJP-Thin.subset.119.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-Thin.subset.119.woff) format('woff');
-	unicode-range: U+a0;
 }
 /* [0] */
 @font-face {
@@ -2137,7 +2128,7 @@ http://scripts.sil.org/OFL
 	font-display: swap;
 	font-weight: 200;
 	src: url(./woff2-dynamic-subset/PretendardJP-ExtraLight.subset.116.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-ExtraLight.subset.116.woff) format('woff');
-	unicode-range: U+4e, U+3000, U+300c-300d, U+4e00, U+4e0a, U+4e2d, U+4e8b, U+4eba, U+4f1a, U+5165, U+5168, U+5185, U+51fa, U+5206, U+5229, U+524d, U+52d5, U+5408, U+554f, U+5831, U+5834, U+5927, U+5b9a, U+5e74, U+5f0f, U+60c5, U+65b0, U+65b9, U+6642, U+6700, U+672c, U+682a, U+6b63, U+6c17, U+7121, U+751f, U+7528, U+753b, U+76ee, U+793e, U+884c, U+898b, U+8a18, U+9593, U+95a2, U+ff01, U+ff08-ff09;
+	unicode-range: U+4e, U+a0, U+3000, U+300c-300d, U+4e00, U+4e0a, U+4e2d, U+4e8b, U+4eba, U+4f1a, U+5165, U+5168, U+5185, U+51fa, U+5206, U+5229, U+524d, U+52d5, U+5408, U+554f, U+5831, U+5834, U+5927, U+5b9a, U+5e74, U+5f0f, U+60c5, U+65b0, U+65b9, U+6642, U+6700, U+672c, U+682a, U+6b63, U+6c17, U+7121, U+751f, U+7528, U+753b, U+76ee, U+793e, U+884c, U+898b, U+8a18, U+9593, U+95a2, U+ff01, U+ff08-ff09;
 }
 /* [117] */
 @font-face {
@@ -2156,15 +2147,6 @@ http://scripts.sil.org/OFL
 	font-weight: 200;
 	src: url(./woff2-dynamic-subset/PretendardJP-ExtraLight.subset.118.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-ExtraLight.subset.118.woff) format('woff');
 	unicode-range: U+20, U+2027, U+3001-3002, U+3041-307f, U+3081-308f, U+3091-3093, U+3099-309a, U+309d-309e, U+30a1-30e1, U+30e3-30ed, U+30ef-30f0, U+30f2-30f4, U+30fb-30fe, U+ff0c, U+ff0e;
-}
-/* [119] */
-@font-face {
-	font-family: 'Pretendard JP';
-	font-style: normal;
-	font-display: swap;
-	font-weight: 200;
-	src: url(./woff2-dynamic-subset/PretendardJP-ExtraLight.subset.119.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-ExtraLight.subset.119.woff) format('woff');
-	unicode-range: U+a0;
 }
 /* [0] */
 @font-face {
@@ -3217,7 +3199,7 @@ http://scripts.sil.org/OFL
 	font-display: swap;
 	font-weight: 300;
 	src: url(./woff2-dynamic-subset/PretendardJP-Light.subset.116.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-Light.subset.116.woff) format('woff');
-	unicode-range: U+4e, U+3000, U+300c-300d, U+4e00, U+4e0a, U+4e2d, U+4e8b, U+4eba, U+4f1a, U+5165, U+5168, U+5185, U+51fa, U+5206, U+5229, U+524d, U+52d5, U+5408, U+554f, U+5831, U+5834, U+5927, U+5b9a, U+5e74, U+5f0f, U+60c5, U+65b0, U+65b9, U+6642, U+6700, U+672c, U+682a, U+6b63, U+6c17, U+7121, U+751f, U+7528, U+753b, U+76ee, U+793e, U+884c, U+898b, U+8a18, U+9593, U+95a2, U+ff01, U+ff08-ff09;
+	unicode-range: U+4e, U+a0, U+3000, U+300c-300d, U+4e00, U+4e0a, U+4e2d, U+4e8b, U+4eba, U+4f1a, U+5165, U+5168, U+5185, U+51fa, U+5206, U+5229, U+524d, U+52d5, U+5408, U+554f, U+5831, U+5834, U+5927, U+5b9a, U+5e74, U+5f0f, U+60c5, U+65b0, U+65b9, U+6642, U+6700, U+672c, U+682a, U+6b63, U+6c17, U+7121, U+751f, U+7528, U+753b, U+76ee, U+793e, U+884c, U+898b, U+8a18, U+9593, U+95a2, U+ff01, U+ff08-ff09;
 }
 /* [117] */
 @font-face {
@@ -3236,15 +3218,6 @@ http://scripts.sil.org/OFL
 	font-weight: 300;
 	src: url(./woff2-dynamic-subset/PretendardJP-Light.subset.118.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-Light.subset.118.woff) format('woff');
 	unicode-range: U+20, U+2027, U+3001-3002, U+3041-307f, U+3081-308f, U+3091-3093, U+3099-309a, U+309d-309e, U+30a1-30e1, U+30e3-30ed, U+30ef-30f0, U+30f2-30f4, U+30fb-30fe, U+ff0c, U+ff0e;
-}
-/* [119] */
-@font-face {
-	font-family: 'Pretendard JP';
-	font-style: normal;
-	font-display: swap;
-	font-weight: 300;
-	src: url(./woff2-dynamic-subset/PretendardJP-Light.subset.119.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-Light.subset.119.woff) format('woff');
-	unicode-range: U+a0;
 }
 /* [0] */
 @font-face {
@@ -4297,7 +4270,7 @@ http://scripts.sil.org/OFL
 	font-display: swap;
 	font-weight: 400;
 	src: url(./woff2-dynamic-subset/PretendardJP-Regular.subset.116.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-Regular.subset.116.woff) format('woff');
-	unicode-range: U+4e, U+3000, U+300c-300d, U+4e00, U+4e0a, U+4e2d, U+4e8b, U+4eba, U+4f1a, U+5165, U+5168, U+5185, U+51fa, U+5206, U+5229, U+524d, U+52d5, U+5408, U+554f, U+5831, U+5834, U+5927, U+5b9a, U+5e74, U+5f0f, U+60c5, U+65b0, U+65b9, U+6642, U+6700, U+672c, U+682a, U+6b63, U+6c17, U+7121, U+751f, U+7528, U+753b, U+76ee, U+793e, U+884c, U+898b, U+8a18, U+9593, U+95a2, U+ff01, U+ff08-ff09;
+	unicode-range: U+4e, U+a0, U+3000, U+300c-300d, U+4e00, U+4e0a, U+4e2d, U+4e8b, U+4eba, U+4f1a, U+5165, U+5168, U+5185, U+51fa, U+5206, U+5229, U+524d, U+52d5, U+5408, U+554f, U+5831, U+5834, U+5927, U+5b9a, U+5e74, U+5f0f, U+60c5, U+65b0, U+65b9, U+6642, U+6700, U+672c, U+682a, U+6b63, U+6c17, U+7121, U+751f, U+7528, U+753b, U+76ee, U+793e, U+884c, U+898b, U+8a18, U+9593, U+95a2, U+ff01, U+ff08-ff09;
 }
 /* [117] */
 @font-face {
@@ -4316,15 +4289,6 @@ http://scripts.sil.org/OFL
 	font-weight: 400;
 	src: url(./woff2-dynamic-subset/PretendardJP-Regular.subset.118.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-Regular.subset.118.woff) format('woff');
 	unicode-range: U+20, U+2027, U+3001-3002, U+3041-307f, U+3081-308f, U+3091-3093, U+3099-309a, U+309d-309e, U+30a1-30e1, U+30e3-30ed, U+30ef-30f0, U+30f2-30f4, U+30fb-30fe, U+ff0c, U+ff0e;
-}
-/* [119] */
-@font-face {
-	font-family: 'Pretendard JP';
-	font-style: normal;
-	font-display: swap;
-	font-weight: 400;
-	src: url(./woff2-dynamic-subset/PretendardJP-Regular.subset.119.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-Regular.subset.119.woff) format('woff');
-	unicode-range: U+a0;
 }
 /* [0] */
 @font-face {
@@ -5377,7 +5341,7 @@ http://scripts.sil.org/OFL
 	font-display: swap;
 	font-weight: 500;
 	src: url(./woff2-dynamic-subset/PretendardJP-Medium.subset.116.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-Medium.subset.116.woff) format('woff');
-	unicode-range: U+4e, U+3000, U+300c-300d, U+4e00, U+4e0a, U+4e2d, U+4e8b, U+4eba, U+4f1a, U+5165, U+5168, U+5185, U+51fa, U+5206, U+5229, U+524d, U+52d5, U+5408, U+554f, U+5831, U+5834, U+5927, U+5b9a, U+5e74, U+5f0f, U+60c5, U+65b0, U+65b9, U+6642, U+6700, U+672c, U+682a, U+6b63, U+6c17, U+7121, U+751f, U+7528, U+753b, U+76ee, U+793e, U+884c, U+898b, U+8a18, U+9593, U+95a2, U+ff01, U+ff08-ff09;
+	unicode-range: U+4e, U+a0, U+3000, U+300c-300d, U+4e00, U+4e0a, U+4e2d, U+4e8b, U+4eba, U+4f1a, U+5165, U+5168, U+5185, U+51fa, U+5206, U+5229, U+524d, U+52d5, U+5408, U+554f, U+5831, U+5834, U+5927, U+5b9a, U+5e74, U+5f0f, U+60c5, U+65b0, U+65b9, U+6642, U+6700, U+672c, U+682a, U+6b63, U+6c17, U+7121, U+751f, U+7528, U+753b, U+76ee, U+793e, U+884c, U+898b, U+8a18, U+9593, U+95a2, U+ff01, U+ff08-ff09;
 }
 /* [117] */
 @font-face {
@@ -5396,15 +5360,6 @@ http://scripts.sil.org/OFL
 	font-weight: 500;
 	src: url(./woff2-dynamic-subset/PretendardJP-Medium.subset.118.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-Medium.subset.118.woff) format('woff');
 	unicode-range: U+20, U+2027, U+3001-3002, U+3041-307f, U+3081-308f, U+3091-3093, U+3099-309a, U+309d-309e, U+30a1-30e1, U+30e3-30ed, U+30ef-30f0, U+30f2-30f4, U+30fb-30fe, U+ff0c, U+ff0e;
-}
-/* [119] */
-@font-face {
-	font-family: 'Pretendard JP';
-	font-style: normal;
-	font-display: swap;
-	font-weight: 500;
-	src: url(./woff2-dynamic-subset/PretendardJP-Medium.subset.119.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-Medium.subset.119.woff) format('woff');
-	unicode-range: U+a0;
 }
 /* [0] */
 @font-face {
@@ -6457,7 +6412,7 @@ http://scripts.sil.org/OFL
 	font-display: swap;
 	font-weight: 600;
 	src: url(./woff2-dynamic-subset/PretendardJP-SemiBold.subset.116.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-SemiBold.subset.116.woff) format('woff');
-	unicode-range: U+4e, U+3000, U+300c-300d, U+4e00, U+4e0a, U+4e2d, U+4e8b, U+4eba, U+4f1a, U+5165, U+5168, U+5185, U+51fa, U+5206, U+5229, U+524d, U+52d5, U+5408, U+554f, U+5831, U+5834, U+5927, U+5b9a, U+5e74, U+5f0f, U+60c5, U+65b0, U+65b9, U+6642, U+6700, U+672c, U+682a, U+6b63, U+6c17, U+7121, U+751f, U+7528, U+753b, U+76ee, U+793e, U+884c, U+898b, U+8a18, U+9593, U+95a2, U+ff01, U+ff08-ff09;
+	unicode-range: U+4e, U+a0, U+3000, U+300c-300d, U+4e00, U+4e0a, U+4e2d, U+4e8b, U+4eba, U+4f1a, U+5165, U+5168, U+5185, U+51fa, U+5206, U+5229, U+524d, U+52d5, U+5408, U+554f, U+5831, U+5834, U+5927, U+5b9a, U+5e74, U+5f0f, U+60c5, U+65b0, U+65b9, U+6642, U+6700, U+672c, U+682a, U+6b63, U+6c17, U+7121, U+751f, U+7528, U+753b, U+76ee, U+793e, U+884c, U+898b, U+8a18, U+9593, U+95a2, U+ff01, U+ff08-ff09;
 }
 /* [117] */
 @font-face {
@@ -6476,15 +6431,6 @@ http://scripts.sil.org/OFL
 	font-weight: 600;
 	src: url(./woff2-dynamic-subset/PretendardJP-SemiBold.subset.118.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-SemiBold.subset.118.woff) format('woff');
 	unicode-range: U+20, U+2027, U+3001-3002, U+3041-307f, U+3081-308f, U+3091-3093, U+3099-309a, U+309d-309e, U+30a1-30e1, U+30e3-30ed, U+30ef-30f0, U+30f2-30f4, U+30fb-30fe, U+ff0c, U+ff0e;
-}
-/* [119] */
-@font-face {
-	font-family: 'Pretendard JP';
-	font-style: normal;
-	font-display: swap;
-	font-weight: 600;
-	src: url(./woff2-dynamic-subset/PretendardJP-SemiBold.subset.119.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-SemiBold.subset.119.woff) format('woff');
-	unicode-range: U+a0;
 }
 /* [0] */
 @font-face {
@@ -7537,7 +7483,7 @@ http://scripts.sil.org/OFL
 	font-display: swap;
 	font-weight: 700;
 	src: url(./woff2-dynamic-subset/PretendardJP-Bold.subset.116.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-Bold.subset.116.woff) format('woff');
-	unicode-range: U+4e, U+3000, U+300c-300d, U+4e00, U+4e0a, U+4e2d, U+4e8b, U+4eba, U+4f1a, U+5165, U+5168, U+5185, U+51fa, U+5206, U+5229, U+524d, U+52d5, U+5408, U+554f, U+5831, U+5834, U+5927, U+5b9a, U+5e74, U+5f0f, U+60c5, U+65b0, U+65b9, U+6642, U+6700, U+672c, U+682a, U+6b63, U+6c17, U+7121, U+751f, U+7528, U+753b, U+76ee, U+793e, U+884c, U+898b, U+8a18, U+9593, U+95a2, U+ff01, U+ff08-ff09;
+	unicode-range: U+4e, U+a0, U+3000, U+300c-300d, U+4e00, U+4e0a, U+4e2d, U+4e8b, U+4eba, U+4f1a, U+5165, U+5168, U+5185, U+51fa, U+5206, U+5229, U+524d, U+52d5, U+5408, U+554f, U+5831, U+5834, U+5927, U+5b9a, U+5e74, U+5f0f, U+60c5, U+65b0, U+65b9, U+6642, U+6700, U+672c, U+682a, U+6b63, U+6c17, U+7121, U+751f, U+7528, U+753b, U+76ee, U+793e, U+884c, U+898b, U+8a18, U+9593, U+95a2, U+ff01, U+ff08-ff09;
 }
 /* [117] */
 @font-face {
@@ -7556,15 +7502,6 @@ http://scripts.sil.org/OFL
 	font-weight: 700;
 	src: url(./woff2-dynamic-subset/PretendardJP-Bold.subset.118.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-Bold.subset.118.woff) format('woff');
 	unicode-range: U+20, U+2027, U+3001-3002, U+3041-307f, U+3081-308f, U+3091-3093, U+3099-309a, U+309d-309e, U+30a1-30e1, U+30e3-30ed, U+30ef-30f0, U+30f2-30f4, U+30fb-30fe, U+ff0c, U+ff0e;
-}
-/* [119] */
-@font-face {
-	font-family: 'Pretendard JP';
-	font-style: normal;
-	font-display: swap;
-	font-weight: 700;
-	src: url(./woff2-dynamic-subset/PretendardJP-Bold.subset.119.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-Bold.subset.119.woff) format('woff');
-	unicode-range: U+a0;
 }
 /* [0] */
 @font-face {
@@ -8617,7 +8554,7 @@ http://scripts.sil.org/OFL
 	font-display: swap;
 	font-weight: 800;
 	src: url(./woff2-dynamic-subset/PretendardJP-ExtraBold.subset.116.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-ExtraBold.subset.116.woff) format('woff');
-	unicode-range: U+4e, U+3000, U+300c-300d, U+4e00, U+4e0a, U+4e2d, U+4e8b, U+4eba, U+4f1a, U+5165, U+5168, U+5185, U+51fa, U+5206, U+5229, U+524d, U+52d5, U+5408, U+554f, U+5831, U+5834, U+5927, U+5b9a, U+5e74, U+5f0f, U+60c5, U+65b0, U+65b9, U+6642, U+6700, U+672c, U+682a, U+6b63, U+6c17, U+7121, U+751f, U+7528, U+753b, U+76ee, U+793e, U+884c, U+898b, U+8a18, U+9593, U+95a2, U+ff01, U+ff08-ff09;
+	unicode-range: U+4e, U+a0, U+3000, U+300c-300d, U+4e00, U+4e0a, U+4e2d, U+4e8b, U+4eba, U+4f1a, U+5165, U+5168, U+5185, U+51fa, U+5206, U+5229, U+524d, U+52d5, U+5408, U+554f, U+5831, U+5834, U+5927, U+5b9a, U+5e74, U+5f0f, U+60c5, U+65b0, U+65b9, U+6642, U+6700, U+672c, U+682a, U+6b63, U+6c17, U+7121, U+751f, U+7528, U+753b, U+76ee, U+793e, U+884c, U+898b, U+8a18, U+9593, U+95a2, U+ff01, U+ff08-ff09;
 }
 /* [117] */
 @font-face {
@@ -8636,15 +8573,6 @@ http://scripts.sil.org/OFL
 	font-weight: 800;
 	src: url(./woff2-dynamic-subset/PretendardJP-ExtraBold.subset.118.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-ExtraBold.subset.118.woff) format('woff');
 	unicode-range: U+20, U+2027, U+3001-3002, U+3041-307f, U+3081-308f, U+3091-3093, U+3099-309a, U+309d-309e, U+30a1-30e1, U+30e3-30ed, U+30ef-30f0, U+30f2-30f4, U+30fb-30fe, U+ff0c, U+ff0e;
-}
-/* [119] */
-@font-face {
-	font-family: 'Pretendard JP';
-	font-style: normal;
-	font-display: swap;
-	font-weight: 800;
-	src: url(./woff2-dynamic-subset/PretendardJP-ExtraBold.subset.119.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-ExtraBold.subset.119.woff) format('woff');
-	unicode-range: U+a0;
 }
 /* [0] */
 @font-face {
@@ -9697,7 +9625,7 @@ http://scripts.sil.org/OFL
 	font-display: swap;
 	font-weight: 900;
 	src: url(./woff2-dynamic-subset/PretendardJP-Black.subset.116.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-Black.subset.116.woff) format('woff');
-	unicode-range: U+4e, U+3000, U+300c-300d, U+4e00, U+4e0a, U+4e2d, U+4e8b, U+4eba, U+4f1a, U+5165, U+5168, U+5185, U+51fa, U+5206, U+5229, U+524d, U+52d5, U+5408, U+554f, U+5831, U+5834, U+5927, U+5b9a, U+5e74, U+5f0f, U+60c5, U+65b0, U+65b9, U+6642, U+6700, U+672c, U+682a, U+6b63, U+6c17, U+7121, U+751f, U+7528, U+753b, U+76ee, U+793e, U+884c, U+898b, U+8a18, U+9593, U+95a2, U+ff01, U+ff08-ff09;
+	unicode-range: U+4e, U+a0, U+3000, U+300c-300d, U+4e00, U+4e0a, U+4e2d, U+4e8b, U+4eba, U+4f1a, U+5165, U+5168, U+5185, U+51fa, U+5206, U+5229, U+524d, U+52d5, U+5408, U+554f, U+5831, U+5834, U+5927, U+5b9a, U+5e74, U+5f0f, U+60c5, U+65b0, U+65b9, U+6642, U+6700, U+672c, U+682a, U+6b63, U+6c17, U+7121, U+751f, U+7528, U+753b, U+76ee, U+793e, U+884c, U+898b, U+8a18, U+9593, U+95a2, U+ff01, U+ff08-ff09;
 }
 /* [117] */
 @font-face {
@@ -9716,13 +9644,4 @@ http://scripts.sil.org/OFL
 	font-weight: 900;
 	src: url(./woff2-dynamic-subset/PretendardJP-Black.subset.118.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-Black.subset.118.woff) format('woff');
 	unicode-range: U+20, U+2027, U+3001-3002, U+3041-307f, U+3081-308f, U+3091-3093, U+3099-309a, U+309d-309e, U+30a1-30e1, U+30e3-30ed, U+30ef-30f0, U+30f2-30f4, U+30fb-30fe, U+ff0c, U+ff0e;
-}
-/* [119] */
-@font-face {
-	font-family: 'Pretendard JP';
-	font-style: normal;
-	font-display: swap;
-	font-weight: 900;
-	src: url(./woff2-dynamic-subset/PretendardJP-Black.subset.119.woff2) format('woff2'), url(./woff-dynamic-subset/PretendardJP-Black.subset.119.woff) format('woff');
-	unicode-range: U+a0;
 }

--- a/docs/readme/en/README.md
+++ b/docs/readme/en/README.md
@@ -43,13 +43,13 @@ Use the code below to use Pretendard as a web font with entire features. Provide
 ###### cdnjs
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/static/pretendard.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/static/pretendard.css" />
 ```
 
 ###### UNPKG
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.1/dist/web/static/pretendard.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.2/dist/web/static/pretendard.css" />
 ```
 
 </details>
@@ -67,13 +67,13 @@ Use the code below to use Pretendard as a web font with entire features. Provide
 ###### cdnjs
 
 ```css
-@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/static/pretendard.css');
+@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/static/pretendard.css');
 ```
 
 ###### UNPKG
 
 ```css
-@import url('https://unpkg.com/pretendard@1.3.1/dist/web/static/pretendard.css');
+@import url('https://unpkg.com/pretendard@1.3.2/dist/web/static/pretendard.css');
 ```
 
 </details>
@@ -97,13 +97,13 @@ Pretendard provides the dynamic subset same as Noto Sans Korean from Google Font
 ###### cdnjs
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/static/pretendard-dynamic-subset.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/static/pretendard-dynamic-subset.css" />
 ```
 
 ###### UNPKG
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.1/dist/web/static/pretendard-dynamic-subset.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.2/dist/web/static/pretendard-dynamic-subset.css" />
 ```
 
 </details>
@@ -121,13 +121,13 @@ Pretendard provides the dynamic subset same as Noto Sans Korean from Google Font
 ###### cdnjs
 
 ```css
-@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/static/pretendard-dynamic-subset.css');
+@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/static/pretendard-dynamic-subset.css');
 ```
 
 ###### UNPKG
 
 ```css
-@import url('https://unpkg.com/pretendard@1.3.1/dist/web/static/pretendard-dynamic-subset.css');
+@import url('https://unpkg.com/pretendard@1.3.2/dist/web/static/pretendard-dynamic-subset.css');
 ```
 
 </details>
@@ -151,13 +151,13 @@ Use the code below to use the variable weight property. Provided font-family nam
 ###### cdnjs
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/variable/pretendardvariable.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/variable/pretendardvariable.css" />
 ```
 
 ###### UNPKG
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.1/dist/web/variable/pretendardvariable.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.2/dist/web/variable/pretendardvariable.css" />
 ```
 
 </details>
@@ -175,13 +175,13 @@ Use the code below to use the variable weight property. Provided font-family nam
 ###### cdnjs
 
 ```css
-@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/variable/pretendardvariable.css');
+@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/variable/pretendardvariable.css');
 ```
 
 ###### UNPKG
 
 ```css
-@import url('https://unpkg.com/pretendard@1.3.1/dist/web/variable/pretendardvariable.css');
+@import url('https://unpkg.com/pretendard@1.3.2/dist/web/variable/pretendardvariable.css');
 ```
 
 </details>

--- a/docs/readme/ja/README.md
+++ b/docs/readme/ja/README.md
@@ -43,13 +43,13 @@ CDNを利用してPretendardを使用することができ、トグルをチェ�
 ###### cdnjs
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/static/pretendard.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/static/pretendard.css" />
 ```
 
 ###### UNPKG
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.1/dist/web/static/pretendard.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.2/dist/web/static/pretendard.css" />
 ```
 
 </details>
@@ -67,13 +67,13 @@ CDNを利用してPretendardを使用することができ、トグルをチェ�
 ###### cdnjs
 
 ```css
-@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/static/pretendard.css');
+@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/static/pretendard.css');
 ```
 
 ###### UNPKG
 
 ```css
-@import url('https://unpkg.com/pretendard@1.3.1/dist/web/static/pretendard.css');
+@import url('https://unpkg.com/pretendard@1.3.2/dist/web/static/pretendard.css');
 ```
 
 </details>
@@ -97,13 +97,13 @@ Pretendardは、Webフォントの容量の問題を解決するための方法�
 ###### cdnjs
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/static/pretendard-dynamic-subset.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/static/pretendard-dynamic-subset.css" />
 ```
 
 ###### UNPKG
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.1/dist/web/static/pretendard-dynamic-subset.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.2/dist/web/static/pretendard-dynamic-subset.css" />
 ```
 
 </details>
@@ -121,13 +121,13 @@ Pretendardは、Webフォントの容量の問題を解決するための方法�
 ###### cdnjs
 
 ```css
-@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/static/pretendard-dynamic-subset.css');
+@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/static/pretendard-dynamic-subset.css');
 ```
 
 ###### UNPKG
 
 ```css
-@import url('https://unpkg.com/pretendard@1.3.1/dist/web/static/pretendard-dynamic-subset.css');
+@import url('https://unpkg.com/pretendard@1.3.2/dist/web/static/pretendard-dynamic-subset.css');
 ```
 
 </details>
@@ -151,13 +151,13 @@ Pretendardは、Webフォントの容量の問題を解決するための方法�
 ###### cdnjs
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/variable/pretendardvariable.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/variable/pretendardvariable.css" />
 ```
 
 ###### UNPKG
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.1/dist/web/variable/pretendardvariable.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.2/dist/web/variable/pretendardvariable.css" />
 ```
 
 </details>
@@ -175,13 +175,13 @@ Pretendardは、Webフォントの容量の問題を解決するための方法�
 ###### cdnjs
 
 ```css
-@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/variable/pretendardvariable.css');
+@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/variable/pretendardvariable.css');
 ```
 
 ###### UNPKG
 
 ```css
-@import url('https://unpkg.com/pretendard@1.3.1/dist/web/variable/pretendardvariable.css');
+@import url('https://unpkg.com/pretendard@1.3.2/dist/web/variable/pretendardvariable.css');
 ```
 
 </details>

--- a/docs/webfonts/en/PretendardJP.md
+++ b/docs/webfonts/en/PretendardJP.md
@@ -17,13 +17,13 @@ To use Korea-localized glyphs, add this code to stylesheets: `font-feature-setti
 ###### cdnjs
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/static/pretendard-jp.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/static/pretendard-jp.css" />
 ```
 
 ###### UNPKG
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.1/dist/web/static/pretendard-jp.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.2/dist/web/static/pretendard-jp.css" />
 ```
 
 </details>
@@ -41,13 +41,13 @@ To use Korea-localized glyphs, add this code to stylesheets: `font-feature-setti
 ###### cdnjs
 
 ```css
-@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/static/pretendard-jp.css');
+@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/static/pretendard-jp.css');
 ```
 
 ###### UNPKG
 
 ```css
-@import url('https://unpkg.com/pretendard@1.3.1/dist/web/static/pretendard-jp.css');
+@import url('https://unpkg.com/pretendard@1.3.2/dist/web/static/pretendard-jp.css');
 ```
 
 </details>
@@ -71,13 +71,13 @@ Use the code below to use Pretendard faster by loads the font-slices required fr
 ###### cdnjs
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/static/pretendard-jp-dynamic-subset.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/static/pretendard-jp-dynamic-subset.css" />
 ```
 
 ###### UNPKG
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.1/dist/web/static/pretendard-jp-dynamic-subset.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.2/dist/web/static/pretendard-jp-dynamic-subset.css" />
 ```
 
 </details>
@@ -95,13 +95,13 @@ Use the code below to use Pretendard faster by loads the font-slices required fr
 ###### cdnjs
 
 ```css
-@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/static/pretendard-jp-dynamic-subset.css');
+@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/static/pretendard-jp-dynamic-subset.css');
 ```
 
 ###### UNPKG
 
 ```css
-@import url('https://unpkg.com/pretendard@1.3.1/dist/web/static/pretendard-jp-dynamic-subset.css');
+@import url('https://unpkg.com/pretendard@1.3.2/dist/web/static/pretendard-jp-dynamic-subset.css');
 ```
 
 </details>
@@ -125,13 +125,13 @@ Use the code below to use the variable weight property. Provided font-family nam
 ###### cdnjs
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/variable/pretendardvariable-jp.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/variable/pretendardvariable-jp.css" />
 ```
 
 ###### UNPKG
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.1/dist/web/variable/pretendardvariable-jp.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.2/dist/web/variable/pretendardvariable-jp.css" />
 ```
 
 </details>
@@ -149,13 +149,13 @@ Use the code below to use the variable weight property. Provided font-family nam
 ###### cdnjs
 
 ```css
-@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/variable/pretendardvariable-jp.css');
+@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/variable/pretendardvariable-jp.css');
 ```
 
 ###### UNPKG
 
 ```css
-@import url('https://unpkg.com/pretendard@1.3.1/dist/web/variable/pretendardvariable-jp.css');
+@import url('https://unpkg.com/pretendard@1.3.2/dist/web/variable/pretendardvariable-jp.css');
 ```
 
 </details>

--- a/docs/webfonts/en/PretendardStd.md
+++ b/docs/webfonts/en/PretendardStd.md
@@ -15,13 +15,13 @@ Use the code below to use Pretendard as a webfonts in a Latin environment with l
 ###### cdnjs
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/static/pretendard-std.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/static/pretendard-std.css" />
 ```
 
 ###### UNPKG
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.1/dist/web/static/pretendard-std.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.2/dist/web/static/pretendard-std.css" />
 ```
 
 </details>
@@ -39,13 +39,13 @@ Use the code below to use Pretendard as a webfonts in a Latin environment with l
 ###### cdnjs
 
 ```css
-@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/static/pretendard-std.css');
+@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/static/pretendard-std.css');
 ```
 
 ###### UNPKG
 
 ```css
-@import url('https://unpkg.com/pretendard@1.3.1/dist/web/static/pretendard-std.css');
+@import url('https://unpkg.com/pretendard@1.3.2/dist/web/static/pretendard-std.css');
 ```
 
 </details>
@@ -69,13 +69,13 @@ Use the code below to use Pretendard faster by loads the font-slices required fr
 ###### cdnjs
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/static/pretendard-std-dynamic-subset.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/static/pretendard-std-dynamic-subset.css" />
 ```
 
 ###### UNPKG
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.1/dist/web/static/pretendard-std-dynamic-subset.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.2/dist/web/static/pretendard-std-dynamic-subset.css" />
 ```
 
 </details>
@@ -93,13 +93,13 @@ Use the code below to use Pretendard faster by loads the font-slices required fr
 ###### cdnjs
 
 ```css
-@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/static/pretendard-std-dynamic-subset.css');
+@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/static/pretendard-std-dynamic-subset.css');
 ```
 
 ###### UNPKG
 
 ```css
-@import url('https://unpkg.com/pretendard@1.3.1/dist/web/static/pretendard-std-dynamic-subset.css');
+@import url('https://unpkg.com/pretendard@1.3.2/dist/web/static/pretendard-std-dynamic-subset.css');
 ```
 
 </details>
@@ -123,13 +123,13 @@ Use the code below to use the variable weight property. Provided font-family nam
 ###### cdnjs
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/variable/pretendardvariable-std.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/variable/pretendardvariable-std.css" />
 ```
 
 ###### UNPKG
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.1/dist/web/variable/pretendardvariable-std.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.2/dist/web/variable/pretendardvariable-std.css" />
 ```
 
 </details>
@@ -147,13 +147,13 @@ Use the code below to use the variable weight property. Provided font-family nam
 ###### cdnjs
 
 ```css
-@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/variable/pretendardvariable-std.css');
+@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/variable/pretendardvariable-std.css');
 ```
 
 ###### UNPKG
 
 ```css
-@import url('https://unpkg.com/pretendard@1.3.1/dist/web/variable/pretendardvariable-std.css');
+@import url('https://unpkg.com/pretendard@1.3.2/dist/web/variable/pretendardvariable-std.css');
 ```
 
 </details>

--- a/docs/webfonts/ja/PretendardJP.md
+++ b/docs/webfonts/ja/PretendardJP.md
@@ -17,13 +17,13 @@
 ###### cdnjs
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/static/pretendard-jp.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/static/pretendard-jp.css" />
 ```
 
 ###### UNPKG
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.1/dist/web/static/pretendard-jp.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.2/dist/web/static/pretendard-jp.css" />
 ```
 
 </details>
@@ -41,13 +41,13 @@
 ###### cdnjs
 
 ```css
-@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/static/pretendard-jp.css');
+@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/static/pretendard-jp.css');
 ```
 
 ###### UNPKG
 
 ```css
-@import url('https://unpkg.com/pretendard@1.3.1/dist/web/static/pretendard-jp.css');
+@import url('https://unpkg.com/pretendard@1.3.2/dist/web/static/pretendard-jp.css');
 ```
 
 </details>
@@ -70,13 +70,13 @@
 ###### cdnjs
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/static/pretendard-jp-dynamic-subset.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/static/pretendard-jp-dynamic-subset.css" />
 ```
 
 ###### UNPKG
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.1/dist/web/static/pretendard-jp-dynamic-subset.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.2/dist/web/static/pretendard-jp-dynamic-subset.css" />
 ```
 
 </details>
@@ -94,13 +94,13 @@
 ###### cdnjs
 
 ```css
-@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/static/pretendard-jp-dynamic-subset.css');
+@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/static/pretendard-jp-dynamic-subset.css');
 ```
 
 ###### UNPKG
 
 ```css
-@import url('https://unpkg.com/pretendard@1.3.1/dist/web/static/pretendard-jp-dynamic-subset.css');
+@import url('https://unpkg.com/pretendard@1.3.2/dist/web/static/pretendard-jp-dynamic-subset.css');
 ```
 
 </details>
@@ -124,13 +124,13 @@
 ###### cdnjs
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/variable/pretendardvariable-jp.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/variable/pretendardvariable-jp.css" />
 ```
 
 ###### UNPKG
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.1/dist/web/variable/pretendardvariable-jp.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.2/dist/web/variable/pretendardvariable-jp.css" />
 ```
 
 </details>
@@ -148,13 +148,13 @@
 ###### cdnjs
 
 ```css
-@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/variable/pretendardvariable-jp.css');
+@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/variable/pretendardvariable-jp.css');
 ```
 
 ###### UNPKG
 
 ```css
-@import url('https://unpkg.com/pretendard@1.3.1/dist/web/variable/pretendardvariable-jp.css');
+@import url('https://unpkg.com/pretendard@1.3.2/dist/web/variable/pretendardvariable-jp.css');
 ```
 
 </details>

--- a/docs/webfonts/ko/PretendardJP.md
+++ b/docs/webfonts/ko/PretendardJP.md
@@ -17,13 +17,13 @@
 ###### cdnjs
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/static/pretendard-jp.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/static/pretendard-jp.css" />
 ```
 
 ###### UNPKG
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.1/dist/web/static/pretendard-jp.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.2/dist/web/static/pretendard-jp.css" />
 ```
 
 </details>
@@ -41,13 +41,13 @@
 ###### cdnjs
 
 ```css
-@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/static/pretendard-jp.css');
+@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/static/pretendard-jp.css');
 ```
 
 ###### UNPKG
 
 ```css
-@import url('https://unpkg.com/pretendard@1.3.1/dist/web/static/pretendard-jp.css');
+@import url('https://unpkg.com/pretendard@1.3.2/dist/web/static/pretendard-jp.css');
 ```
 
 </details>
@@ -71,13 +71,13 @@
 ###### cdnjs
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/static/pretendard-jp-dynamic-subset.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/static/pretendard-jp-dynamic-subset.css" />
 ```
 
 ###### UNPKG
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.1/dist/web/static/pretendard-jp-dynamic-subset.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.2/dist/web/static/pretendard-jp-dynamic-subset.css" />
 ```
 
 </details>
@@ -95,13 +95,13 @@
 ###### cdnjs
 
 ```css
-@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/static/pretendard-jp-dynamic-subset.css');
+@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/static/pretendard-jp-dynamic-subset.css');
 ```
 
 ###### UNPKG
 
 ```css
-@import url('https://unpkg.com/pretendard@1.3.1/dist/web/static/pretendard-jp-dynamic-subset.css');
+@import url('https://unpkg.com/pretendard@1.3.2/dist/web/static/pretendard-jp-dynamic-subset.css');
 ```
 
 </details>
@@ -125,13 +125,13 @@
 ###### cdnjs
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/variable/pretendardvariable-jp.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/variable/pretendardvariable-jp.css" />
 ```
 
 ###### UNPKG
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.1/dist/web/variable/pretendardvariable-jp.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.2/dist/web/variable/pretendardvariable-jp.css" />
 ```
 
 </details>
@@ -149,13 +149,13 @@
 ###### cdnjs
 
 ```css
-@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/variable/pretendardvariable-jp.css');
+@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/variable/pretendardvariable-jp.css');
 ```
 
 ###### UNPKG
 
 ```css
-@import url('https://unpkg.com/pretendard@1.3.1/dist/web/variable/pretendardvariable-jp.css');
+@import url('https://unpkg.com/pretendard@1.3.2/dist/web/variable/pretendardvariable-jp.css');
 ```
 
 </details>

--- a/docs/webfonts/ko/PretendardStd.md
+++ b/docs/webfonts/ko/PretendardStd.md
@@ -15,13 +15,13 @@
 ###### cdnjs
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/static/pretendard-std.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/static/pretendard-std.css" />
 ```
 
 ###### UNPKG
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.1/dist/web/static/pretendard-std.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.2/dist/web/static/pretendard-std.css" />
 ```
 
 </details>
@@ -39,13 +39,13 @@
 ###### cdnjs
 
 ```css
-@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/static/pretendard-std.css');
+@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/static/pretendard-std.css');
 ```
 
 ###### UNPKG
 
 ```css
-@import url('https://unpkg.com/pretendard@1.3.1/dist/web/static/pretendard-std.css');
+@import url('https://unpkg.com/pretendard@1.3.2/dist/web/static/pretendard-std.css');
 ```
 
 </details>
@@ -69,13 +69,13 @@
 ###### cdnjs
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/static/pretendard-std-dynamic-subset.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/static/pretendard-std-dynamic-subset.css" />
 ```
 
 ###### UNPKG
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.1/dist/web/static/pretendard-std-dynamic-subset.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.2/dist/web/static/pretendard-std-dynamic-subset.css" />
 ```
 
 </details>
@@ -93,13 +93,13 @@
 ###### cdnjs
 
 ```css
-@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/static/pretendard-std-dynamic-subset.css');
+@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/static/pretendard-std-dynamic-subset.css');
 ```
 
 ###### UNPKG
 
 ```css
-@import url('https://unpkg.com/pretendard@1.3.1/dist/web/static/pretendard-std-dynamic-subset.css');
+@import url('https://unpkg.com/pretendard@1.3.2/dist/web/static/pretendard-std-dynamic-subset.css');
 ```
 
 </details>
@@ -123,13 +123,13 @@
 ###### cdnjs
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/variable/pretendardvariable-std.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/variable/pretendardvariable-std.css" />
 ```
 
 ###### UNPKG
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.1/dist/web/variable/pretendardvariable-std.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.2/dist/web/variable/pretendardvariable-std.css" />
 ```
 
 </details>
@@ -147,13 +147,13 @@
 ###### cdnjs
 
 ```css
-@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.1/variable/pretendardvariable-std.css');
+@import url('https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.2/variable/pretendardvariable-std.css');
 ```
 
 ###### UNPKG
 
 ```css
-@import url('https://unpkg.com/pretendard@1.3.1/dist/web/variable/pretendardvariable-std.css');
+@import url('https://unpkg.com/pretendard@1.3.2/dist/web/variable/pretendardvariable-std.css');
 ```
 
 </details>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pretendard",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pretendard",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "OFL-1.1",
       "dependencies": {
         "font-range": "^0.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pretendard",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "repository": "https://github.com/orioncactus/pretendard",
   "author": "Kil Hyung-jin <orioncactus@gmail.com>",
   "license": "OFL-1.1",


### PR DESCRIPTION
## 개요
다이나믹 서브셋에서 발생하는 문제를 개선하며, 다이나믹 서브셋을 제외한 파일은 이전과 동일합니다.

### Safari에서 다이나믹 서브셋 이슈 개선
- Safari에서 다이나믹 서브셋으로 제공하는 Pretendard를 사용할 때 nbspacce(`&nbsp;`)가 정상적으로 표시되지 않는 문제를 해결합니다.