### PR TITLE
docs: Add system font installation section

### DIFF
--- a/packages/pretendard-jp/README.md
+++ b/packages/pretendard-jp/README.md
@@ -171,3 +171,25 @@
 ```css
 font-family: "Pretendard JP", Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Hiragino Sans", "Apple SD Gothic Neo", Meiryo, "Noto Sans JP", "Noto Sans KR", "Malgun Gothic", Osaka, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
 ```
+
+## 시스템 폰트
+
+Pretendard JP를 기기에 설치해 시스템 폰트로 사용할 수 있습니다.
+
+- [homebrew-cask-fonts](https://github.com/Homebrew/homebrew-cask-fonts)
+
+```bash
+brew tap homebrew/cask-fonts
+brew install font-pretendard-jp
+```
+
+- [nix](https://github.com/NixOS/nixpkgs)
+
+```nix
+# configuration.nix
+{
+  fonts.fonts = with pkgs; [
+    pretendard-jp
+  ];
+}
+```

--- a/packages/pretendard-jp/docs/en/README.md
+++ b/packages/pretendard-jp/docs/en/README.md
@@ -171,3 +171,25 @@ If you want to provide a comfortable environment anywhere, the following font-fa
 ```css
 font-family: "Pretendard JP", Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Hiragino Sans", "Apple SD Gothic Neo", Meiryo,   "Noto Sans JP", "Noto Sans KR", "Malgun Gothic", Osaka, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
 ```
+
+## System font
+
+Pretendard JP can be installed on the machine and used as a system font.
+
+- [homebrew-cask-fonts](https://github.com/Homebrew/homebrew-cask-fonts)
+
+```bash
+brew tap homebrew/cask-fonts
+brew install font-pretendard-jp
+```
+
+- [nix](https://github.com/NixOS/nixpkgs)
+
+```nix
+# configuration.nix
+{
+  fonts.fonts = with pkgs; [
+    pretendard-jp
+  ];
+}
+```

--- a/packages/pretendard-jp/docs/ja/README.md
+++ b/packages/pretendard-jp/docs/ja/README.md
@@ -171,3 +171,25 @@
 ```css
 font-family: "Pretendard JP", Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Hiragino Sans", "Apple SD Gothic Neo", Meiryo, "Noto Sans JP", "Noto Sans KR", "Malgun Gothic", Osaka, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
 ```
+
+## システムフォント
+
+Pretendard JPはデバイスにインストールしてシステムフォントとして使用できます。
+
+- [homebrew-cask-fonts](https://github.com/Homebrew/homebrew-cask-fonts)
+
+```bash
+brew tap homebrew/cask-fonts
+brew install font-pretendard-jp
+```
+
+- [nix](https://github.com/NixOS/nixpkgs)
+
+```nix
+# configuration.nix
+{
+  fonts.fonts = with pkgs; [
+    pretendard-jp
+  ];
+}
+```

--- a/packages/pretendard-std/README.md
+++ b/packages/pretendard-std/README.md
@@ -175,3 +175,25 @@ font-family: -apple-system, BlinkMacSystemFont, "Pretendard Std", Pretendard, Ro
 ```css
 font-family: "Pretendard Std", Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
 ```
+
+## 시스템 폰트
+
+Pretendard Std를 기기에 설치해 시스템 폰트로 사용할 수 있습니다.
+
+- [homebrew-cask-fonts](https://github.com/Homebrew/homebrew-cask-fonts)
+
+```bash
+brew tap homebrew/cask-fonts
+brew install font-pretendard-std
+```
+
+- [nix](https://github.com/NixOS/nixpkgs)
+
+```nix
+# configuration.nix
+{
+  fonts.fonts = with pkgs; [
+    pretendard-std
+  ];
+}
+```

--- a/packages/pretendard-std/docs/en/README.md
+++ b/packages/pretendard-std/docs/en/README.md
@@ -175,3 +175,25 @@ If you want to provide the same environment anywhere, the following font-family 
 ```css
 font-family: "Pretendard Std", Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
 ```
+
+## System font
+
+Pretendard Std can be installed on the machine and used as a system font.
+
+- [homebrew-cask-fonts](https://github.com/Homebrew/homebrew-cask-fonts)
+
+```bash
+brew tap homebrew/cask-fonts
+brew install font-pretendard-std
+```
+
+- [nix](https://github.com/NixOS/nixpkgs)
+
+```nix
+# configuration.nix
+{
+  fonts.fonts = with pkgs; [
+    pretendard-std
+  ];
+}
+```

--- a/packages/pretendard/README.md
+++ b/packages/pretendard/README.md
@@ -218,6 +218,35 @@ npm i pretendard
 yarn add pretendard
 ```
 
+## 시스템 폰트
+
+Pretendard를 기기에 설치해 시스템 폰트로 사용할 수 있습니다.
+
+- [homebrew-cask-fonts](https://github.com/Homebrew/homebrew-cask-fonts)
+
+```bash
+brew tap homebrew/cask-fonts
+brew install font-pretendard
+```
+
+- [nix](https://github.com/NixOS/nixpkgs)
+
+```nix
+# configuration.nix
+{
+  fonts.fonts = with pkgs; [
+    pretendard
+  ];
+}
+```
+
+- [AUR](https://aur.archlinux.org/packages?K=pretendard)
+
+```bash
+yay -S otf-pretendard
+yay -S ttf-pretendard
+```
+
 ## 라이선스
 
 Pretendard는 [SIL 오픈 폰트 라이선스](https://scripts.sil.org/OFL)로 배포됩니다. 글꼴 단독 판매를 제외한 모든 상업적 행위 및 수정, 재배포가 가능합니다.

--- a/packages/pretendard/docs/en/README.md
+++ b/packages/pretendard/docs/en/README.md
@@ -218,6 +218,35 @@ npm i pretendard
 yarn add pretendard
 ```
 
+## System font
+
+Pretendard can be installed on the machine and used as a system font.
+
+- [homebrew-cask-fonts](https://github.com/Homebrew/homebrew-cask-fonts)
+
+```bash
+brew tap homebrew/cask-fonts
+brew install font-pretendard
+```
+
+- [nix](https://github.com/NixOS/nixpkgs)
+
+```nix
+# configuration.nix
+{
+  fonts.fonts = with pkgs; [
+    pretendard
+  ];
+}
+```
+
+- [AUR](https://aur.archlinux.org/packages?K=pretendard)
+
+```bash
+yay -S otf-pretendard
+yay -S ttf-pretendard
+```
+
 ## License
 
 Pretendard is distributed under the [SIL Open Fonts License](https://scripts.sil.org/OFL), which is allowed any commercial uses, modifications, and redistribution.

--- a/packages/pretendard/docs/ja/README.md
+++ b/packages/pretendard/docs/ja/README.md
@@ -218,6 +218,35 @@ npm i pretendard
 yarn add pretendard
 ```
 
+## システムフォント
+
+Pretendardはデバイスにインストールしてシステムフォントとして使用できます。
+
+- [homebrew-cask-fonts](https://github.com/Homebrew/homebrew-cask-fonts)
+
+```bash
+brew tap homebrew/cask-fonts
+brew install font-pretendard
+```
+
+- [nix](https://github.com/NixOS/nixpkgs)
+
+```nix
+# configuration.nix
+{
+  fonts.fonts = with pkgs; [
+    pretendard
+  ];
+}
+```
+
+- [AUR](https://aur.archlinux.org/packages?K=pretendard)
+
+```bash
+yay -S otf-pretendard
+yay -S ttf-pretendard
+```
+
 ## ライセンス
 
 Pretendardは[SIL Open Font License](https://scripts.sil.org/OFL)として配布されています。フォントの単独販売を除くすべての商業行為、修正、再配布が可能です。


### PR DESCRIPTION
### Summary

I thought a lot of people (including myself) wanted to use Pretendard as a system font. So I've contributed some channels upstream, made easy to install and use Pretendard.

### About channels

- homebrew-cask-fonts: https://github.com/Homebrew/homebrew-cask-fonts/pull/5991
  - Init at `v1.3.4`
  - Packages: `font-pretendard`, `font-pretendard-jp`, and `font-pretendard-std`
  - Many macOS users use [homebrew](https://brew.sh/) as a primary package manager.
- nix: https://github.com/NixOS/nixpkgs/pull/173281, https://github.com/NixOS/nixpkgs/pull/179806
  - Init at `v1.3.0`, upgraded to `v1.3.3`
  - Packages: `pretendard`, `pretendard-jp`, and `pretendard-std`
  - Some users use NixOS or nix-darwin, and this packages can help.
  - `v1.3.4` has the same release output as `v1.3.3`, so I didn't update the nix package yet.
- AUR: https://aur.archlinux.org/packages?K=pretendard
  - Current at `v1.3.0`
  - AUR is not my contribution, but there are also many users with Arch Linux, so I documented it.

### About languages

- Korean, English are my primary, seoncdary language.
- Japanese is not my major, so feedback is welcome.
