### PR TITLE
Pretendard를 사용하는 곳에 HOLIX 추가

### DIFF
--- a/packages/pretendard/README.md
+++ b/packages/pretendard/README.md
@@ -369,6 +369,9 @@ Pretendard에 기여해주셔서 진심으로 감사드립니다.
    <a href="https://www.opencheongwadae.kr/#gh-dark-mode-only">
       <img src="https://user-images.githubusercontent.com/67222970/173811541-d70e58d2-3fa8-4afe-b91a-942ce47a8dcf.png" align="center" height="30" alt="청와대, 국민 품으로" hspace="16">
    </a>
+   <a href="https://holix.com">
+      <img src="https://user-images.githubusercontent.com/7759511/178255186-32d8403d-cc25-4b63-b96e-1fd1c707957f.png" align="center" height="50" alt="HOLIX" hspace="16">
+   </a>
 </p>
 
 ## 의견 나누기


### PR DESCRIPTION
안녕하세요. [HOLIX](holix.com)의 웹, 안드로이드, iOS 모든 클라이언트에서 Pretendard를 사용하고 있습니다.
좋은 폰트를 만들어주셔서 감사합니다. 감사함을 담아 사용하는 곳에 이름을 더해보고자 합니다.

여담이지만, Google Font 등재도 기대하고 issue #7 를 지켜보고 있습니다👍
저는 안드로이드 개발을 담당하고 있는데, Pretendard 적용을 위해 폰트 파일을 앱에 포함해야해서 5MB 가량 앱 사이즈가 증가하게 되었습니다. 5MB는 꽤 큰 사이즈인데, 이러한 문제를 해결하기 위해 Google은 `Downloadble Font`라는 기능을 제공합니다. 
 Google Font에 등재가 된 후, Pretendard를 `Downloadable Font`로서 안드로이드 프로젝트에 import하는 가이드를 작성해보겠습니다 😊 새로운 UI 프레임워크인 `Jetpack Compose`도 최근 `Downloadable Font`를 지원하게 되었는데, 그 내용 또한 포함될 것 같네요. 