### PR TITLE
fix: spawn args quotation marks

### DIFF
--- a/packages/subset-utils/src/normal-subset.ts
+++ b/packages/subset-utils/src/normal-subset.ts
@@ -19,7 +19,7 @@ function font_subset(
     `--flavor=${format}`,
     "--with-zopfli",
     `--output-file=${outputPath}`,
-    "--layout-features='*'",
+    "--layout-features=*",
     "--glyph-names",
     "--symbol-cmap",
     "--legacy-cmap",
@@ -28,8 +28,8 @@ function font_subset(
     "--recommended-glyphs",
     "--name-legacy",
     "--drop-tables=",
-    "--name-IDs='*'",
-    "--name-languages='*'",
+    "--name-IDs=*",
+    "--name-languages=*",
     glyphOption ? GLYPH_OPTION :  NON_GLYPH_OPTION
   ];
 


### PR DESCRIPTION
## 개요
child_process 모듈의 spawn 함수를 호출시 string 배열로 정의된 args의 일부 아이템에서 작은 따옴표를 사용하여 올바르게 작동하지 않는 문제를 해결합니다.

- Resolves #85 