### PR TITLE
Pretendard를 사용하는 곳에 한컴독스 추가

### DIFF
--- a/packages/pretendard/README.md
+++ b/packages/pretendard/README.md
@@ -409,10 +409,10 @@ Pretendard에 기여해주셔서 진심으로 감사드립니다.
       <img src="https://user-images.githubusercontent.com/67222970/191770855-499e4268-42b8-4fd0-9aeb-1468928240e2.png" align="center" height="30" alt="iamport" hspace="16">
    </a>
    <a href="https://www.hancomdocs.com/#gh-light-mode-only">
-      <img src="https://user-images.githubusercontent.com/67222970/193015090-2988de41-a3f8-410c-9067-771725328ecd.png" align="center" height="30" alt="iamport" hspace="16">
+      <img src="https://user-images.githubusercontent.com/67222970/193015090-2988de41-a3f8-410c-9067-771725328ecd.png" align="center" height="30" alt="한컴독스" hspace="16">
    </a>
    <a href="https://www.hancomdocs.com/#gh-dark-mode-only">
-      <img src="https://user-images.githubusercontent.com/67222970/193015153-66ed803c-cf26-43fc-8f2e-dab8673e0774.png" align="center" height="30" alt="iamport" hspace="16">
+      <img src="https://user-images.githubusercontent.com/67222970/193015153-66ed803c-cf26-43fc-8f2e-dab8673e0774.png" align="center" height="30" alt="한컴독스" hspace="16">
    </a>
 </p>
 

--- a/packages/pretendard/README.md
+++ b/packages/pretendard/README.md
@@ -408,6 +408,12 @@ Pretendard에 기여해주셔서 진심으로 감사드립니다.
    <a href="https://www.iamport.kr/#gh-dark-mode-only">
       <img src="https://user-images.githubusercontent.com/67222970/191770855-499e4268-42b8-4fd0-9aeb-1468928240e2.png" align="center" height="30" alt="iamport" hspace="16">
    </a>
+   <a href="https://www.hancomdocs.com/#gh-light-mode-only">
+      <img src="https://user-images.githubusercontent.com/67222970/193015090-2988de41-a3f8-410c-9067-771725328ecd.png" align="center" height="30" alt="iamport" hspace="16">
+   </a>
+   <a href="https://www.hancomdocs.com/#gh-dark-mode-only">
+      <img src="https://user-images.githubusercontent.com/67222970/193015153-66ed803c-cf26-43fc-8f2e-dab8673e0774.png" align="center" height="30" alt="iamport" hspace="16">
+   </a>
 </p>
 
 ## 의견 나누기


### PR DESCRIPTION
- 확인가능한 Path: https://www.hancomdocs.com/

![image](https://user-images.githubusercontent.com/67222970/193015972-c009a387-1b1b-450d-a731-fb8f34055766.png)
![image](https://user-images.githubusercontent.com/67222970/193015777-6162ba19-835b-41d5-888d-8d3898d89d36.png)
![image](https://user-images.githubusercontent.com/67222970/193015744-60c530ee-0ba2-4bb5-b7dd-ca500c518767.png)

참고: Body에는 Noto Sans KR이 사용 중이나 대부분의 클래스에는 또 Pretendard를 설정해 두었습니다.
현재 주요 섹션 3가지(위 사진 참고)에는 Pretendard가 적용되어 있습니다.