### PR TITLE
:pencil2: docs(readme): cdnjs, unpkg 링크 오류 수정

### DIFF
--- a/packages/pretendard-jp/README.md
+++ b/packages/pretendard-jp/README.md
@@ -19,13 +19,13 @@
 ###### cdnjs
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.6/static/pretendard-jp.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard-jp/1.3.6/static/pretendard-jp.css" />
 ```
 
 ###### UNPKG
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.6/dist/web/static/pretendard-jp.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard-jp@1.3.6/dist/web/static/pretendard-jp.css" />
 ```
 
 </details>
@@ -43,13 +43,13 @@
 ###### cdnjs
 
 ```css
-@import url("https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.6/static/pretendard-jp.css");
+@import url("https://cdnjs.cloudflare.com/ajax/libs/pretendard-jp/1.3.6/static/pretendard-jp.css");
 ```
 
 ###### UNPKG
 
 ```css
-@import url("https://unpkg.com/pretendard@1.3.6/dist/web/static/pretendard-jp.css");
+@import url("https://unpkg.com/pretendard-jp@1.3.6/dist/web/static/pretendard-jp.css");
 ```
 
 </details>
@@ -73,13 +73,13 @@
 ###### cdnjs
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.6/static/pretendard-jp-dynamic-subset.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard-jp/1.3.6/static/pretendard-jp-dynamic-subset.css" />
 ```
 
 ###### UNPKG
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.6/dist/web/static/pretendard-jp-dynamic-subset.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard-jp@1.3.6/dist/web/static/pretendard-jp-dynamic-subset.css" />
 ```
 
 </details>
@@ -97,13 +97,13 @@
 ###### cdnjs
 
 ```css
-@import url("https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.6/static/pretendard-jp-dynamic-subset.css");
+@import url("https://cdnjs.cloudflare.com/ajax/libs/pretendard-jp/1.3.6/static/pretendard-jp-dynamic-subset.css");
 ```
 
 ###### UNPKG
 
 ```css
-@import url("https://unpkg.com/pretendard@1.3.6/dist/web/static/pretendard-jp-dynamic-subset.css");
+@import url("https://unpkg.com/pretendard-jp@1.3.6/dist/web/static/pretendard-jp-dynamic-subset.css");
 ```
 
 </details>
@@ -127,13 +127,13 @@
 ###### cdnjs
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.6/variable/pretendardvariable-jp-dynamic-subset.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard-jp/1.3.6/variable/pretendardvariable-jp-dynamic-subset.css" />
 ```
 
 ###### UNPKG
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.6/dist/web/variable/pretendardvariable-jp-dynamic-subset.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard-jp@1.3.6/dist/web/variable/pretendardvariable-jp-dynamic-subset.css" />
 ```
 
 </details>
@@ -151,13 +151,13 @@
 ###### cdnjs
 
 ```css
-@import url("https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.6/variable/pretendardvariable-jp-dynamic-subset.css");
+@import url("https://cdnjs.cloudflare.com/ajax/libs/pretendard-jp/1.3.6/variable/pretendardvariable-jp-dynamic-subset.css");
 ```
 
 ###### UNPKG
 
 ```css
-@import url("https://unpkg.com/pretendard@1.3.6/dist/web/variable/pretendardvariable-jp-dynamic-subset.css");
+@import url("https://unpkg.com/pretendard-jp@1.3.6/dist/web/variable/pretendardvariable-jp-dynamic-subset.css");
 ```
 
 </details>
@@ -179,13 +179,13 @@
 ###### cdnjs
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.6/variable/pretendardvariable-jp.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard-jp/1.3.6/variable/pretendardvariable-jp.css" />
 ```
 
 ###### UNPKG
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.6/dist/web/variable/pretendardvariable-jp.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard-jp@1.3.6/dist/web/variable/pretendardvariable-jp.css" />
 ```
 
 </details>
@@ -203,13 +203,13 @@
 ###### cdnjs
 
 ```css
-@import url("https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.6/variable/pretendardvariable-jp.css");
+@import url("https://cdnjs.cloudflare.com/ajax/libs/pretendard-jp/1.3.6/variable/pretendardvariable-jp.css");
 ```
 
 ###### UNPKG
 
 ```css
-@import url("https://unpkg.com/pretendard@1.3.6/dist/web/variable/pretendardvariable-jp.css");
+@import url("https://unpkg.com/pretendard-jp@1.3.6/dist/web/variable/pretendardvariable-jp.css");
 ```
 
 </details>

--- a/packages/pretendard-jp/docs/en/README.md
+++ b/packages/pretendard-jp/docs/en/README.md
@@ -19,13 +19,13 @@ To use Korea-localized glyphs, add this code to stylesheets: `font-feature-setti
 ###### cdnjs
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.6/static/pretendard-jp.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard-jp/1.3.6/static/pretendard-jp.css" />
 ```
 
 ###### UNPKG
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.6/dist/web/static/pretendard-jp.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard-jp@1.3.6/dist/web/static/pretendard-jp.css" />
 ```
 
 </details>
@@ -43,13 +43,13 @@ To use Korea-localized glyphs, add this code to stylesheets: `font-feature-setti
 ###### cdnjs
 
 ```css
-@import url("https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.6/static/pretendard-jp.css");
+@import url("https://cdnjs.cloudflare.com/ajax/libs/pretendard-jp/1.3.6/static/pretendard-jp.css");
 ```
 
 ###### UNPKG
 
 ```css
-@import url("https://unpkg.com/pretendard@1.3.6/dist/web/static/pretendard-jp.css");
+@import url("https://unpkg.com/pretendard-jp@1.3.6/dist/web/static/pretendard-jp.css");
 ```
 
 </details>
@@ -73,13 +73,13 @@ Use the code below to use Pretendard JP faster by loads the font-slices required
 ###### cdnjs
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.6/static/pretendard-jp-dynamic-subset.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard-jp/1.3.6/static/pretendard-jp-dynamic-subset.css" />
 ```
 
 ###### UNPKG
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.6/dist/web/static/pretendard-jp-dynamic-subset.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard-jp@1.3.6/dist/web/static/pretendard-jp-dynamic-subset.css" />
 ```
 
 </details>
@@ -97,13 +97,13 @@ Use the code below to use Pretendard JP faster by loads the font-slices required
 ###### cdnjs
 
 ```css
-@import url("https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.6/static/pretendard-jp-dynamic-subset.css");
+@import url("https://cdnjs.cloudflare.com/ajax/libs/pretendard-jp/1.3.6/static/pretendard-jp-dynamic-subset.css");
 ```
 
 ###### UNPKG
 
 ```css
-@import url("https://unpkg.com/pretendard@1.3.6/dist/web/static/pretendard-jp-dynamic-subset.css");
+@import url("https://unpkg.com/pretendard-jp@1.3.6/dist/web/static/pretendard-jp-dynamic-subset.css");
 ```
 
 </details>
@@ -127,13 +127,13 @@ You can use Pretendard JP dynamic subset much faster and smaller file size with 
 ###### cdnjs
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.6/variable/pretendardvariable-jp-dynamic-subset.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard-jp/1.3.6/variable/pretendardvariable-jp-dynamic-subset.css" />
 ```
 
 ###### UNPKG
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.6/dist/web/variable/pretendardvariable-jp-dynamic-subset.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard-jp@1.3.6/dist/web/variable/pretendardvariable-jp-dynamic-subset.css" />
 ```
 
 </details>
@@ -151,13 +151,13 @@ You can use Pretendard JP dynamic subset much faster and smaller file size with 
 ###### cdnjs
 
 ```css
-@import url("https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.6/variable/pretendardvariable-jp-dynamic-subset.css");
+@import url("https://cdnjs.cloudflare.com/ajax/libs/pretendard-jp/1.3.6/variable/pretendardvariable-jp-dynamic-subset.css");
 ```
 
 ###### UNPKG
 
 ```css
-@import url("https://unpkg.com/pretendard@1.3.6/dist/web/variable/pretendardvariable-jp-dynamic-subset.css");
+@import url("https://unpkg.com/pretendard-jp@1.3.6/dist/web/variable/pretendardvariable-jp-dynamic-subset.css");
 ```
 
 </details>
@@ -181,13 +181,13 @@ Use the code below to use Pretendard JP with a variable weight axis. Provided fo
 ###### cdnjs
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.6/variable/pretendardvariable-jp.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard-jp/1.3.6/variable/pretendardvariable-jp.css" />
 ```
 
 ###### UNPKG
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.6/dist/web/variable/pretendardvariable-jp.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard-jp@1.3.6/dist/web/variable/pretendardvariable-jp.css" />
 ```
 
 </details>
@@ -205,13 +205,13 @@ Use the code below to use Pretendard JP with a variable weight axis. Provided fo
 ###### cdnjs
 
 ```css
-@import url("https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.6/variable/pretendardvariable-jp.css");
+@import url("https://cdnjs.cloudflare.com/ajax/libs/pretendard-jp/1.3.6/variable/pretendardvariable-jp.css");
 ```
 
 ###### UNPKG
 
 ```css
-@import url("https://unpkg.com/pretendard@1.3.6/dist/web/variable/pretendardvariable-jp.css");
+@import url("https://unpkg.com/pretendard-jp@1.3.6/dist/web/variable/pretendardvariable-jp.css");
 ```
 
 </details>

--- a/packages/pretendard-jp/docs/ja/README.md
+++ b/packages/pretendard-jp/docs/ja/README.md
@@ -19,13 +19,13 @@
 ###### cdnjs
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.6/static/pretendard-jp.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard-jp/1.3.6/static/pretendard-jp.css" />
 ```
 
 ###### UNPKG
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.6/dist/web/static/pretendard-jp.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard-jp@1.3.6/dist/web/static/pretendard-jp.css" />
 ```
 
 </details>
@@ -43,13 +43,13 @@
 ###### cdnjs
 
 ```css
-@import url("https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.6/static/pretendard-jp.css");
+@import url("https://cdnjs.cloudflare.com/ajax/libs/pretendard-jp/1.3.6/static/pretendard-jp.css");
 ```
 
 ###### UNPKG
 
 ```css
-@import url("https://unpkg.com/pretendard@1.3.6/dist/web/static/pretendard-jp.css");
+@import url("https://unpkg.com/pretendard-jp@1.3.6/dist/web/static/pretendard-jp.css");
 ```
 
 </details>
@@ -73,13 +73,13 @@
 ###### cdnjs
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.6/static/pretendard-jp-dynamic-subset.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard-jp/1.3.6/static/pretendard-jp-dynamic-subset.css" />
 ```
 
 ###### UNPKG
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.6/dist/web/static/pretendard-jp-dynamic-subset.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard-jp@1.3.6/dist/web/static/pretendard-jp-dynamic-subset.css" />
 ```
 
 </details>
@@ -97,13 +97,13 @@
 ###### cdnjs
 
 ```css
-@import url("https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.6/static/pretendard-jp-dynamic-subset.css");
+@import url("https://cdnjs.cloudflare.com/ajax/libs/pretendard-jp/1.3.6/static/pretendard-jp-dynamic-subset.css");
 ```
 
 ###### UNPKG
 
 ```css
-@import url("https://unpkg.com/pretendard@1.3.6/dist/web/static/pretendard-jp-dynamic-subset.css");
+@import url("https://unpkg.com/pretendard-jp@1.3.6/dist/web/static/pretendard-jp-dynamic-subset.css");
 ```
 
 </details>
@@ -128,13 +128,13 @@
 ###### cdnjs
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.6/variable/pretendardvariable-jp-dynamic-subset.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard-jp/1.3.6/variable/pretendardvariable-jp-dynamic-subset.css" />
 ```
 
 ###### UNPKG
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.6/dist/web/variable/pretendardvariable-jp-dynamic-subset.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard-jp@1.3.6/dist/web/variable/pretendardvariable-jp-dynamic-subset.css" />
 ```
 
 </details>
@@ -152,13 +152,13 @@
 ###### cdnjs
 
 ```css
-@import url("https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.6/variable/pretendardvariable-jp-dynamic-subset.css");
+@import url("https://cdnjs.cloudflare.com/ajax/libs/pretendard-jp/1.3.6/variable/pretendardvariable-jp-dynamic-subset.css");
 ```
 
 ###### UNPKG
 
 ```css
-@import url("https://unpkg.com/pretendard@1.3.6/dist/web/variable/pretendardvariable-jp-dynamic-subset.css");
+@import url("https://unpkg.com/pretendard-jp@1.3.6/dist/web/variable/pretendardvariable-jp-dynamic-subset.css");
 ```
 
 </details>
@@ -182,13 +182,13 @@
 ###### cdnjs
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.6/variable/pretendardvariable-jp.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard-jp/1.3.6/variable/pretendardvariable-jp.css" />
 ```
 
 ###### UNPKG
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.6/dist/web/variable/pretendardvariable-jp.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard-jp@1.3.6/dist/web/variable/pretendardvariable-jp.css" />
 ```
 
 </details>
@@ -206,13 +206,13 @@
 ###### cdnjs
 
 ```css
-@import url("https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.6/variable/pretendardvariable-jp.css");
+@import url("https://cdnjs.cloudflare.com/ajax/libs/pretendard-jp/1.3.6/variable/pretendardvariable-jp.css");
 ```
 
 ###### UNPKG
 
 ```css
-@import url("https://unpkg.com/pretendard@1.3.6/dist/web/variable/pretendardvariable-jp.css");
+@import url("https://unpkg.com/pretendard-jp@1.3.6/dist/web/variable/pretendardvariable-jp.css");
 ```
 
 </details>

--- a/packages/pretendard-std/README.md
+++ b/packages/pretendard-std/README.md
@@ -17,13 +17,13 @@
 ###### cdnjs
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.6/static/pretendard-std.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard-std/1.3.6/static/pretendard-std.css" />
 ```
 
 ###### UNPKG
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.6/dist/web/static/pretendard-std.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard-std@1.3.6/dist/web/static/pretendard-std.css" />
 ```
 
 </details>
@@ -41,13 +41,13 @@
 ###### cdnjs
 
 ```css
-@import url("https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.6/static/pretendard-std.css");
+@import url("https://cdnjs.cloudflare.com/ajax/libs/pretendard-std/1.3.6/static/pretendard-std.css");
 ```
 
 ###### UNPKG
 
 ```css
-@import url("https://unpkg.com/pretendard@1.3.6/dist/web/static/pretendard-std.css");
+@import url("https://unpkg.com/pretendard-std@1.3.6/dist/web/static/pretendard-std.css");
 ```
 
 </details>
@@ -71,13 +71,13 @@
 ###### cdnjs
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.6/static/pretendard-std-dynamic-subset.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard-std/1.3.6/static/pretendard-std-dynamic-subset.css" />
 ```
 
 ###### UNPKG
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.6/dist/web/static/pretendard-std-dynamic-subset.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard-std@1.3.6/dist/web/static/pretendard-std-dynamic-subset.css" />
 ```
 
 </details>
@@ -95,13 +95,13 @@
 ###### cdnjs
 
 ```css
-@import url("https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.6/static/pretendard-std-dynamic-subset.css");
+@import url("https://cdnjs.cloudflare.com/ajax/libs/pretendard-std/1.3.6/static/pretendard-std-dynamic-subset.css");
 ```
 
 ###### UNPKG
 
 ```css
-@import url("https://unpkg.com/pretendard@1.3.6/dist/web/static/pretendard-std-dynamic-subset.css");
+@import url("https://unpkg.com/pretendard-std@1.3.6/dist/web/static/pretendard-std-dynamic-subset.css");
 ```
 
 </details>
@@ -125,13 +125,13 @@
 ###### cdnjs
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.6/variable/pretendardvariable-std-dynamic-subset.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard-std/1.3.6/variable/pretendardvariable-std-dynamic-subset.css" />
 ```
 
 ###### UNPKG
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.6/dist/web/variable/pretendardvariable-std-dynamic-subset.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard-std@1.3.6/dist/web/variable/pretendardvariable-std-dynamic-subset.css" />
 ```
 
 </details>
@@ -149,13 +149,13 @@
 ###### cdnjs
 
 ```css
-@import url("https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.6/variable/pretendardvariable-std-dynamic-subset.css");
+@import url("https://cdnjs.cloudflare.com/ajax/libs/pretendard-std/1.3.6/variable/pretendardvariable-std-dynamic-subset.css");
 ```
 
 ###### UNPKG
 
 ```css
-@import url("https://unpkg.com/pretendard@1.3.6/dist/web/variable/pretendardvariable-std-dynamic-subset.css");
+@import url("https://unpkg.com/pretendard-std@1.3.6/dist/web/variable/pretendardvariable-std-dynamic-subset.css");
 ```
 
 </details>
@@ -177,13 +177,13 @@
 ###### cdnjs
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.6/variable/pretendardvariable-std.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://cdnjs.cloudflare.com/ajax/libs/pretendard-std/1.3.6/variable/pretendardvariable-std.css" />
 ```
 
 ###### UNPKG
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.6/dist/web/variable/pretendardvariable-std.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard-std@1.3.6/dist/web/variable/pretendardvariable-std.css" />
 ```
 
 </details>
@@ -201,13 +201,13 @@
 ###### cdnjs
 
 ```css
-@import url("https://cdnjs.cloudflare.com/ajax/libs/pretendard/1.3.6/variable/pretendardvariable-std.css");
+@import url("https://cdnjs.cloudflare.com/ajax/libs/pretendard-std/1.3.6/variable/pretendardvariable-std.css");
 ```
 
 ###### UNPKG
 
 ```css
-@import url("https://unpkg.com/pretendard@1.3.6/dist/web/variable/pretendardvariable-std.css");
+@import url("https://unpkg.com/pretendard-std@1.3.6/dist/web/variable/pretendardvariable-std.css");
 ```
 
 </details>

--- a/packages/pretendard-std/docs/en/README.md
+++ b/packages/pretendard-std/docs/en/README.md
@@ -23,7 +23,7 @@ Use the code below to use Pretendard as a webfonts in a Latin environment with a
 ###### UNPKG
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.6/dist/web/static/pretendard-std.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard-std@1.3.6/dist/web/static/pretendard-std.css" />
 ```
 
 </details>
@@ -47,7 +47,7 @@ Use the code below to use Pretendard as a webfonts in a Latin environment with a
 ###### UNPKG
 
 ```css
-@import url("https://unpkg.com/pretendard@1.3.6/dist/web/static/pretendard-std.css");
+@import url("https://unpkg.com/pretendard-std@1.3.6/dist/web/static/pretendard-std.css");
 ```
 
 </details>
@@ -77,7 +77,7 @@ Use the code below to use Pretendard Std faster by loads the font-slices require
 ###### UNPKG
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.6/dist/web/static/pretendard-std-dynamic-subset.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard-std@1.3.6/dist/web/static/pretendard-std-dynamic-subset.css" />
 ```
 
 </details>
@@ -101,7 +101,7 @@ Use the code below to use Pretendard Std faster by loads the font-slices require
 ###### UNPKG
 
 ```css
-@import url("https://unpkg.com/pretendard@1.3.6/dist/web/static/pretendard-std-dynamic-subset.css");
+@import url("https://unpkg.com/pretendard-std@1.3.6/dist/web/static/pretendard-std-dynamic-subset.css");
 ```
 
 </details>
@@ -131,7 +131,7 @@ You can use Pretendard Std dynamic subset much faster and smaller file size with
 ###### UNPKG
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.6/dist/web/variable/pretendardvariable-std-dynamic-subset.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard-std@1.3.6/dist/web/variable/pretendardvariable-std-dynamic-subset.css" />
 ```
 
 </details>
@@ -155,7 +155,7 @@ You can use Pretendard Std dynamic subset much faster and smaller file size with
 ###### UNPKG
 
 ```css
-@import url("https://unpkg.com/pretendard@1.3.6/dist/web/variable/pretendardvariable-std-dynamic-subset.css");
+@import url("https://unpkg.com/pretendard-std@1.3.6/dist/web/variable/pretendardvariable-std-dynamic-subset.css");
 ```
 
 </details>
@@ -185,7 +185,7 @@ Use the code below to use Pretendard Std with a variable weight axis. Provided f
 ###### UNPKG
 
 ```html
-<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard@1.3.6/dist/web/variable/pretendardvariable-std.css" />
+<link rel="stylesheet" as="style" crossorigin href="https://unpkg.com/pretendard-std@1.3.6/dist/web/variable/pretendardvariable-std.css" />
 ```
 
 </details>
@@ -209,7 +209,7 @@ Use the code below to use Pretendard Std with a variable weight axis. Provided f
 ###### UNPKG
 
 ```css
-@import url("https://unpkg.com/pretendard@1.3.6/dist/web/variable/pretendardvariable-std.css");
+@import url("https://unpkg.com/pretendard-std@1.3.6/dist/web/variable/pretendardvariable-std.css");
 ```
 
 </details>


### PR DESCRIPTION
현재 해당 링크로 접속하면 404가 발생하길래, 링크가 작동하도록 문서를 수정했습니다.
@orioncactus 