### PR TITLE
Pretendard를 사용하는 곳 추가

### DIFF
--- a/packages/pretendard/README.md
+++ b/packages/pretendard/README.md
@@ -602,6 +602,13 @@ Pretendard에 기여해주셔서 진심으로 감사드립니다.
          <img src="https://github-production-user-asset-6210df.s3.amazonaws.com/7247848/238140309-e26336cb-fa6a-409f-8663-c02ea0d15a2b.png" align="center" height="50" alt="모바일 신분증" hspace="16">
       </picture>
    </a>
+   <a href="https://www.musinsa.com/">
+      <picture>
+         <source media="(prefers-color-scheme: dark)" srcset="https://github.com/orioncactus/pretendard/assets/4019262/e17aed65-e52d-46a5-a3fc-9358b9382f7f">
+         <img src="https://github.com/orioncactus/pretendard/assets/4019262/e17aed65-e52d-46a5-a3fc-9358b9382f7f"
+         align="center" height="30" alt="무신사" hspace="16">
+      </picture>
+   </a>
 </p>
 
 ## 의견 나누기


### PR DESCRIPTION
부분적으로 적용되고 있길래, 추가해둡니다.
다른 로고랑 달리 위 아래 여백이 없어 이미지 사이즈를 조정해두었습니다.

공식 CI/BI는 [여기](https://newsroom.musinsa.com/news/library) 에 있습니다.

아래 이미지 처럼 노출돼요.

<img width="836" alt="스크린샷 2023-05-31 오후 4 56 09" src="https://github.com/orioncactus/pretendard/assets/4019262/8a91edac-c024-4073-af68-5a356035ef3b">