### PR TITLE
라이트모드에서의 무신사 로고

### DIFF
--- a/packages/pretendard/README.md
+++ b/packages/pretendard/README.md
@@ -608,8 +608,8 @@ Pretendard에 기여해주셔서 진심으로 감사드립니다.
    <a href="https://www.musinsa.com/">
       <picture>
          <source media="(prefers-color-scheme: dark)" srcset="https://github.com/orioncactus/pretendard/assets/4019262/e17aed65-e52d-46a5-a3fc-9358b9382f7f">
-         <img src="https://github.com/orioncactus/pretendard/assets/4019262/e17aed65-e52d-46a5-a3fc-9358b9382f7f"
-         align="center" height="30" alt="무신사" hspace="16">
+         <img src="https://github.com/orioncactus/pretendard/assets/25581533/216609df-5c14-4ea6-92b8-7a202d360126"
+         align="center" height="22" alt="무신사" hspace="16">
       </picture>
    </a>
 </p>


### PR DESCRIPTION
무신사의 로고가 다크모드에서는 잘 보이지만 #134

라이트모드에서는 잘 보이지 않아 수정했습니다.

- 수정전
![image](https://github.com/orioncactus/pretendard/assets/25581533/0a69f7ff-c52d-440e-8a84-a80ad146913c)

- 수정후
![image](https://github.com/orioncactus/pretendard/assets/25581533/33a72021-b59b-47b6-93b9-9ee85bfe55a3)
