### PR TITLE
update jsdelivr-purge version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,5 +61,5 @@ jobs:
       with:
         fetch-depth: 0
     - name: Run jsDelivr-Purge
-      uses: List-KR/jsdelivr-purge@5.3.0
+      uses: List-KR/jsdelivr-purge@5.4.0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,5 +61,5 @@ jobs:
       with:
         fetch-depth: 0
     - name: Run jsDelivr-Purge
-      uses: List-KR/jsdelivr-purge@5.4.0
+      uses: List-KR/jsdelivr-purge@5.5.0
 


### PR DESCRIPTION
수정 사항은 다음과 같습니다:
 - dependencies와 devDependencies를 업데이트했습니다.
 - jsDelivr API에 대해 디버깅을 쉽게 만들게 위해 API 응답을 항상 출력합니다. 이 때, 이 데이터는 비공개로 해야 할 필요는 없습니다.
 - jsDelivr API에 대해 디버깅을 쉽게 만들게 위해 workflow run이 실행되는 GitHub의 Action runner의 IP를 출력합니다. 따라서, GitHub이 무료로 호스팅해주는 GitHub의 Action runner를 선택해주시는 것을 권장합니다.
 - 추후에 문제가 없게끔 하기 위해 GitHub RAW 파일 ( `https://github.com/${Repo}/raw/${BranchOrTag}/${Filename}` )와 레파지토리에 있는 파일 간의 SHA3-256 을 검사합니다.
 - SHA3-256 검사와 Purge 하는 동안의 소요 시간을 각각 출력합니다.