### PR TITLE
Next.js 에서 로컬 폰트를 사용하는 방법 문서화

### DIFF
--- a/packages/pretendard/README.md
+++ b/packages/pretendard/README.md
@@ -306,6 +306,22 @@ yay -S otf-pretendard
 yay -S ttf-pretendard
 ```
 
+## Next.js
+
+Next.js에서 로컬 폰트 기능을 활용하여 Pretendard를 사용할 수 있습니다.
+
+```ts
+import localFont from 'next/font/local'
+
+const pretendard = localFont({
+  src: './fonts/PretendardVariable.woff2',
+  display: 'swap',
+  weight: '45 920',
+})
+```
+
+`weight` 옵션을 지정하지 않으면 WebKit 기반의 브라우저에서 굵기가 잘못 렌더링 될 수 있으니 주의해 주세요.
+
 ## 크레딧
 
 #### 바탕


### PR DESCRIPTION
`localFont` 사용 시 `weight` 옵션을 빠뜨리면 WebKit 기반 브라우저에서 아래와 같이 잘못 렌더링 되는 경우가 있습니다. 실수하지 않도록 문서에서 사용 방법을 안내합니다.

<img width="175" alt="Screenshot 2024-02-21 at 7 01 03 PM" src="https://github.com/orioncactus/pretendard/assets/931655/d144df48-4208-4cba-893e-92b033567f32">
