### PR TITLE
update List-KR/jsdelivr-purge version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,5 +61,5 @@ jobs:
       with:
         fetch-depth: 0
     - name: Run jsDelivr-Purge
-      uses: List-KR/jsdelivr-purge@5.5.0
+      uses: List-KR/jsdelivr-purge@5.6.0
 


### PR DESCRIPTION
수정 사항은 다음과 같습니다:
 - jsDelivr 관리자로부터 대부분의 경우에서는 git repository를 clone하고 난 뒤에 purge 요청을 처리한다고 하여 hash 검사 기능을 제거했습니다.
 - 의존성을 업데이트했습니다.
 - git branch 리스트를 가져오는 로직 스타일을 수정하여 파일이 삭제되었을 때 발생하는 문제를 수정했습니다.
 - jsDelivr 서버에 특정 파일에 대한 purge 요청이 rate-limit에 도달하여 purge를 하지 못했을 때 경고 메시지를 표시합니다.
 - GitHub workflow 파일경로를 찾기 위해 사용하는 정규 표현식을 수정했습니다.
 - got 패키지를 통한 HTTP 요청에 들어가는 User-agent 를 수정했습니다.