### PR TITLE
docs: Update instructions for using fonts on NixOS

### DIFF
--- a/packages/pretendard-jp/README.md
+++ b/packages/pretendard-jp/README.md
@@ -235,12 +235,12 @@ brew tap homebrew/cask-fonts
 brew install font-pretendard-jp
 ```
 
--   [nix](https://github.com/NixOS/nixpkgs)
+-   [NixOS](https://nixos.org)
 
 ```nix
 # configuration.nix
 {
-  fonts.fonts = with pkgs; [
+  fonts.packages = with pkgs; [
     pretendard-jp
   ];
 }

--- a/packages/pretendard-jp/docs/en/README.md
+++ b/packages/pretendard-jp/docs/en/README.md
@@ -237,12 +237,12 @@ brew tap homebrew/cask-fonts
 brew install font-pretendard-jp
 ```
 
--   [nix](https://github.com/NixOS/nixpkgs)
+-   [NixOS](https://nixos.org)
 
 ```nix
 # configuration.nix
 {
-  fonts.fonts = with pkgs; [
+  fonts.packages = with pkgs; [
     pretendard-jp
   ];
 }

--- a/packages/pretendard-jp/docs/ja/README.md
+++ b/packages/pretendard-jp/docs/ja/README.md
@@ -238,12 +238,12 @@ brew tap homebrew/cask-fonts
 brew install font-pretendard-jp
 ```
 
--   [nix](https://github.com/NixOS/nixpkgs)
+-   [NixOS](https://nixos.org)
 
 ```nix
 # configuration.nix
 {
-  fonts.fonts = with pkgs; [
+  fonts.packages = with pkgs; [
     pretendard-jp
   ];
 }

--- a/packages/pretendard-std/README.md
+++ b/packages/pretendard-std/README.md
@@ -239,12 +239,12 @@ brew tap homebrew/cask-fonts
 brew install font-pretendard-std
 ```
 
--   [nix](https://github.com/NixOS/nixpkgs)
+-   [NixOS](https://nixos.org)
 
 ```nix
 # configuration.nix
 {
-  fonts.fonts = with pkgs; [
+  fonts.packages = with pkgs; [
     pretendard-std
   ];
 }

--- a/packages/pretendard-std/docs/en/README.md
+++ b/packages/pretendard-std/docs/en/README.md
@@ -241,12 +241,12 @@ brew tap homebrew/cask-fonts
 brew install font-pretendard-std
 ```
 
--   [nix](https://github.com/NixOS/nixpkgs)
+-   [NixOS](https://nixos.org)
 
 ```nix
 # configuration.nix
 {
-  fonts.fonts = with pkgs; [
+  fonts.packages = with pkgs; [
     pretendard-std
   ];
 }

--- a/packages/pretendard/README.md
+++ b/packages/pretendard/README.md
@@ -288,12 +288,12 @@ brew tap homebrew/cask-fonts
 brew install font-pretendard
 ```
 
--   [nix](https://github.com/NixOS/nixpkgs)
+-   [NixOS](https://nixos.org)
 
 ```nix
 # configuration.nix
 {
-  fonts.fonts = with pkgs; [
+  fonts.packages = with pkgs; [
     pretendard
   ];
 }

--- a/packages/pretendard/docs/en/README.md
+++ b/packages/pretendard/docs/en/README.md
@@ -288,12 +288,12 @@ brew tap homebrew/cask-fonts
 brew install font-pretendard
 ```
 
--   [nix](https://github.com/NixOS/nixpkgs)
+-   [NixOS](https://nixos.org)
 
 ```nix
 # configuration.nix
 {
-  fonts.fonts = with pkgs; [
+  fonts.packages = with pkgs; [
     pretendard
   ];
 }

--- a/packages/pretendard/docs/ja/README.md
+++ b/packages/pretendard/docs/ja/README.md
@@ -287,12 +287,12 @@ brew tap homebrew/cask-fonts
 brew install font-pretendard
 ```
 
--   [nix](https://github.com/NixOS/nixpkgs)
+-   [NixOS](https://nixos.org)
 
 ```nix
 # configuration.nix
 {
-  fonts.fonts = with pkgs; [
+  fonts.packages = with pkgs; [
     pretendard
   ];
 }


### PR DESCRIPTION
NixOS 23.11 부터 `fonts.fonts`에서 `fonts.packages`로 변경되었습니다. 