### PR TITLE
readme: `homebrew-cask-fonts`의 deprecation에 따른 `brew install` 명령어 업데이트

### DIFF
--- a/packages/pretendard-jp/README.md
+++ b/packages/pretendard-jp/README.md
@@ -228,11 +228,10 @@ font-family: "Pretendard JP Variable", "Pretendard JP", Pretendard, -apple-syste
 
 Pretendard JP를 기기에 설치해 시스템 폰트로 사용할 수 있습니다.
 
--   [homebrew-cask-fonts](https://github.com/Homebrew/homebrew-cask-fonts)
+-   [Homebrew Cask](https://formulae.brew.sh/cask/font-pretendard-jp)
 
 ```bash
-brew tap homebrew/cask-fonts
-brew install font-pretendard-jp
+brew install --cask font-pretendard-jp
 ```
 
 -   [NixOS](https://nixos.org)

--- a/packages/pretendard-jp/docs/en/README.md
+++ b/packages/pretendard-jp/docs/en/README.md
@@ -230,11 +230,10 @@ font-family: "Pretendard JP Variable", "Pretendard JP", Pretendard, -apple-syste
 
 Pretendard JP can be installed on the machine and used as a system font.
 
--   [homebrew-cask-fonts](https://github.com/Homebrew/homebrew-cask-fonts)
+-   [Homebrew Cask](https://formulae.brew.sh/cask/font-pretendard-jp)
 
 ```bash
-brew tap homebrew/cask-fonts
-brew install font-pretendard-jp
+brew install --cask font-pretendard-jp
 ```
 
 -   [NixOS](https://nixos.org)

--- a/packages/pretendard-jp/docs/ja/README.md
+++ b/packages/pretendard-jp/docs/ja/README.md
@@ -231,11 +231,10 @@ font-family: "Pretendard JP Variable", "Pretendard JP", Pretendard, -apple-syste
 
 Pretendard JPはデバイスにインストールしてシステムフォントとして使用できます。
 
--   [homebrew-cask-fonts](https://github.com/Homebrew/homebrew-cask-fonts)
+-   [Homebrew Cask](https://formulae.brew.sh/cask/font-pretendard-jp)
 
 ```bash
-brew tap homebrew/cask-fonts
-brew install font-pretendard-jp
+brew install --cask font-pretendard-jp
 ```
 
 -   [NixOS](https://nixos.org)

--- a/packages/pretendard-std/README.md
+++ b/packages/pretendard-std/README.md
@@ -232,11 +232,10 @@ font-family: "Pretendard Std Variable", "Pretendard Std", Pretendard, -apple-sys
 
 Pretendard Std를 기기에 설치해 시스템 폰트로 사용할 수 있습니다.
 
--   [homebrew-cask-fonts](https://github.com/Homebrew/homebrew-cask-fonts)
+-   [Homebrew Cask](https://formulae.brew.sh/cask/font-pretendard-std)
 
 ```bash
-brew tap homebrew/cask-fonts
-brew install font-pretendard-std
+brew install --cask font-pretendard-std
 ```
 
 -   [NixOS](https://nixos.org)

--- a/packages/pretendard-std/docs/en/README.md
+++ b/packages/pretendard-std/docs/en/README.md
@@ -234,11 +234,10 @@ font-family: "Pretendard Std Variable", "Pretendard Std", Pretendard, -apple-sys
 
 Pretendard Std can be installed on the machine and used as a system font.
 
--   [homebrew-cask-fonts](https://github.com/Homebrew/homebrew-cask-fonts)
+-   [Homebrew Cask](https://formulae.brew.sh/cask/font-pretendard-std)
 
 ```bash
-brew tap homebrew/cask-fonts
-brew install font-pretendard-std
+brew install --cask font-pretendard-std
 ```
 
 -   [NixOS](https://nixos.org)

--- a/packages/pretendard/README.md
+++ b/packages/pretendard/README.md
@@ -281,11 +281,10 @@ yarn add pretendard
 
 Pretendard를 기기에 설치해 시스템 폰트로 사용할 수 있습니다.
 
--   [homebrew-cask-fonts](https://github.com/Homebrew/homebrew-cask-fonts)
+-   [Homebrew Cask](https://formulae.brew.sh/cask/font-pretendard)
 
 ```bash
-brew tap homebrew/cask-fonts
-brew install font-pretendard
+brew install --cask font-pretendard
 ```
 
 -   [NixOS](https://nixos.org)

--- a/packages/pretendard/docs/en/README.md
+++ b/packages/pretendard/docs/en/README.md
@@ -281,11 +281,10 @@ yarn add pretendard
 
 Pretendard can be installed on the machine and used as a system font.
 
--   [homebrew-cask-fonts](https://github.com/Homebrew/homebrew-cask-fonts)
+-   [Homebrew Cask](https://formulae.brew.sh/cask/font-pretendard)
 
 ```bash
-brew tap homebrew/cask-fonts
-brew install font-pretendard
+brew install --cask font-pretendard
 ```
 
 -   [NixOS](https://nixos.org)

--- a/packages/pretendard/docs/ja/README.md
+++ b/packages/pretendard/docs/ja/README.md
@@ -280,11 +280,10 @@ yarn add pretendard
 
 Pretendardはデバイスにインストールしてシステムフォントとして使用できます。
 
--   [homebrew-cask-fonts](https://github.com/Homebrew/homebrew-cask-fonts)
+-   [Homebrew Cask](https://formulae.brew.sh/cask/font-pretendard)
 
 ```bash
-brew tap homebrew/cask-fonts
-brew install font-pretendard
+brew install --cask font-pretendard
 ```
 
 -   [NixOS](https://nixos.org)


### PR DESCRIPTION
형진님 안녕하세요 :) 지난번 당근에서 디자인 시스템 관련하여 만나뵀었던 Max.kim입니다. 잘 지내시는지요?

macOS를 새로 세팅하면서 Homebrew로 프리텐다드를 설치하려고 하니, `brew tap` 명령어가 더 이상 동작하지 않더라고요.

```bash
$ brew tap homebrew/cask-fonts
Error: homebrew/cask-fonts was deprecated. This tap is now empty and all its contents were either deleted or migrated.
```

자세히 알아보니 [`homebrew/cask-fonts`](https://github.com/Homebrew/homebrew-cask-fonts)가 deprecated되면서 [`homebrew-cask`](https://github.com/Homebrew/homebrew-cask/blob/master/Casks/font/font-p/font-pretendard.rb)로 공식 이전된 것으로 확인되어, 아래와 같이 전체 `README.md`의 Homebrew 설치 가이드를 업데이트하기 위해 PR을 올립니다.

프리텐다드 항상 잘 쓰고 있습니다. 감사합니다 :)