### PR TITLE
Fix: README.md 미리 캔버스 로고 링크 수정

### DIFF
--- a/packages/pretendard/README.md
+++ b/packages/pretendard/README.md
@@ -577,7 +577,7 @@ Pretendard에 기여해주셔서 진심으로 감사드립니다.
       </picture>
    </a>
    <a href="https://www.miricanvas.com" target="_blank">
-   <img align="center" alt="미리캔버스" height="50" hspace="16" src="https://raw.githubusercontent.com/orioncactus/pretendard/main/docs/images/logo/light/%EB%AF%B8%EB%A6%AC%EC%BA%94%EB%B2%84%EC%8A%A4%0A.png"/>
+   <img align="center" alt="미리캔버스" height="50" hspace="16" src="https://raw.githubusercontent.com/orioncactus/pretendard/main/docs/images/logo/light/%EB%AF%B8%EB%A6%AC%EC%BA%94%EB%B2%84%EC%8A%A4.png"/>
    </a>
    <a href="https://www.ssfshop.com" target="_blank">
       <picture>
@@ -708,3 +708,4 @@ Pretendard에 기여해주셔서 진심으로 감사드립니다.
 ## 의견 나누기
 
 새로운 개선 의견은 언제나 환영입니다. 해결이 필요한 경우 [Issues](https://github.com/orioncactus/pretendard/issues)에서 이슈를 등록해주세요.
+

--- a/packages/pretendard/README.md
+++ b/packages/pretendard/README.md
@@ -708,4 +708,3 @@ Pretendard에 기여해주셔서 진심으로 감사드립니다.
 ## 의견 나누기
 
 새로운 개선 의견은 언제나 환영입니다. 해결이 필요한 경우 [Issues](https://github.com/orioncactus/pretendard/issues)에서 이슈를 등록해주세요.
-


### PR DESCRIPTION
README.md의 `미리 캔버스` 로고에 이미지 파일 주소가 잘못 연결되어 있는 것을 수정하였습니다.

## 수정 전
<img width="629" height="470" alt="image" src="https://github.com/user-attachments/assets/98068905-adba-40ff-814a-48f3b189c624" />

## 수정 후
<img width="625" height="509" alt="image" src="https://github.com/user-attachments/assets/d08e2f4d-012c-4764-bf81-98dfd6db5360" />
