### PR TITLE
inter, mplus fonts license 에서 RFN 제거

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -5,11 +5,9 @@ Copyright 2014-2021 Adobe (http://www.adobe.com/),
 with Reserved Font Name 'Source'.
 Source is a trademark of Adobe in the United States and/or other countries.
 
-Copyright (c) 2016 The Inter Project Authors (https://github.com/rsms/inter),
-with Reserved Font Name 'Inter'.
+Copyright (c) 2016 The Inter Project Authors (https://github.com/rsms/inter)
 
-Copyright 2021 The M+ FONTS Project Authors (https://github.com/coz-m/MPLUS_FONTS),
-with Reserved Font Name 'M PLUS 1'.
+Copyright 2021 The M+ FONTS Project Authors (https://github.com/coz-m/MPLUS_FONTS)
 
 This Font Software is licensed under the SIL Open Font License, Version 1.1.
 This license is copied below, and is also available with a FAQ at:

--- a/packages/pretendard-gov/dist/LICENSE.txt
+++ b/packages/pretendard-gov/dist/LICENSE.txt
@@ -5,11 +5,9 @@ Copyright 2014-2021 Adobe (http://www.adobe.com/),
 with Reserved Font Name 'Source'.
 Source is a trademark of Adobe in the United States and/or other countries.
 
-Copyright (c) 2016 The Inter Project Authors (https://github.com/rsms/inter),
-with Reserved Font Name 'Inter'.
+Copyright (c) 2016 The Inter Project Authors (https://github.com/rsms/inter)
 
-Copyright 2021 The M+ FONTS Project Authors (https://github.com/coz-m/MPLUS_FONTS),
-with Reserved Font Name 'M PLUS 1'.
+Copyright 2021 The M+ FONTS Project Authors (https://github.com/coz-m/MPLUS_FONTS)
 
 This Font Software is licensed under the SIL Open Font License, Version 1.1.
 This license is copied below, and is also available with a FAQ at:

--- a/packages/pretendard-jp/dist/LICENSE.txt
+++ b/packages/pretendard-jp/dist/LICENSE.txt
@@ -5,11 +5,9 @@ Copyright 2014-2021 Adobe (http://www.adobe.com/),
 with Reserved Font Name 'Source'.
 Source is a trademark of Adobe in the United States and/or other countries.
 
-Copyright (c) 2016 The Inter Project Authors (https://github.com/rsms/inter),
-with Reserved Font Name 'Inter'.
+Copyright (c) 2016 The Inter Project Authors (https://github.com/rsms/inter)
 
-Copyright 2021 The M+ FONTS Project Authors (https://github.com/coz-m/MPLUS_FONTS),
-with Reserved Font Name 'M PLUS 1'.
+Copyright 2021 The M+ FONTS Project Authors (https://github.com/coz-m/MPLUS_FONTS)
 
 This Font Software is licensed under the SIL Open Font License, Version 1.1.
 This license is copied below, and is also available with a FAQ at:

--- a/packages/pretendard-std/dist/LICENSE.txt
+++ b/packages/pretendard-std/dist/LICENSE.txt
@@ -5,11 +5,9 @@ Copyright 2014-2021 Adobe (http://www.adobe.com/),
 with Reserved Font Name 'Source'.
 Source is a trademark of Adobe in the United States and/or other countries.
 
-Copyright (c) 2016 The Inter Project Authors (https://github.com/rsms/inter),
-with Reserved Font Name 'Inter'.
+Copyright (c) 2016 The Inter Project Authors (https://github.com/rsms/inter)
 
-Copyright 2021 The M+ FONTS Project Authors (https://github.com/coz-m/MPLUS_FONTS),
-with Reserved Font Name 'M PLUS 1'.
+Copyright 2021 The M+ FONTS Project Authors (https://github.com/coz-m/MPLUS_FONTS)
 
 This Font Software is licensed under the SIL Open Font License, Version 1.1.
 This license is copied below, and is also available with a FAQ at:

--- a/packages/pretendard/dist/LICENSE.txt
+++ b/packages/pretendard/dist/LICENSE.txt
@@ -5,11 +5,9 @@ Copyright 2014-2021 Adobe (http://www.adobe.com/),
 with Reserved Font Name 'Source'.
 Source is a trademark of Adobe in the United States and/or other countries.
 
-Copyright (c) 2016 The Inter Project Authors (https://github.com/rsms/inter),
-with Reserved Font Name 'Inter'.
+Copyright (c) 2016 The Inter Project Authors (https://github.com/rsms/inter)
 
-Copyright 2021 The M+ FONTS Project Authors (https://github.com/coz-m/MPLUS_FONTS),
-with Reserved Font Name 'M PLUS 1'.
+Copyright 2021 The M+ FONTS Project Authors (https://github.com/coz-m/MPLUS_FONTS)
 
 This Font Software is licensed under the SIL Open Font License, Version 1.1.
 This license is copied below, and is also available with a FAQ at:


### PR DESCRIPTION
## 요약

라이선스에 포함된 아래 Reserved Font Name 선언을 제거합니다.

* `with Reserved Font Name 'Inter'.`
* `with Reserved Font Name 'M PLUS 1'.`

## 배경

#192 에서 @changwoo 님이 말씀해주셔서 인지하였습니다.

SIL Open Font License 1.1에서 Reserved Font Name은 저작권 고지 뒤에 Reserved Font Name으로 명시적으로 지정된 이름을 의미합니다.

- https://openfontlicense.org/ofl-faq/

하지만 현재 Inter와 M PLUS의 upstream 라이선스에서는 각각 `Inter`, `M PLUS 1`을 Reserved Font Name으로 지정하고 있지 않습니다.

- Inter: https://github.com/rsms/inter/blob/master/LICENSE.txt
- M PLUS: https://github.com/coz-m/MPLUS_FONTS/blob/master/OFL.txt

Inter의 경우 2020년 8월에 `"Inter" is a Reserved Font Name.` 문구가 한 차례 추가되었지만, 이후 곧바로 제거되었고 trademark 고지로 변경된 이력이 있습니다.

https://github.com/rsms/inter/commit/ca221fe038d6fbad4d9333bc90e63a1603f955c5

M PLUS의 경우 upstream OFL에서 `M PLUS 1`을 Reserved Font Name으로 선언한 기록을 확인하기 어렵습니다.

따라서 현재 Pretendard 라이선스의 두 문구는 각 upstream 라이선스에서 유래한 RFN 선언으로 보기 어렵고, OFL상 해당 이름이 Reserved Font Name인 것처럼 오해를 줄 수 있어 제거합니다.

이번 변경은 위 두 RFN 선언만 제거하며, 각 원저작자의 저작권 고지와 그 외 라이선스 내용은 변경하지 않습니다.